### PR TITLE
Adding OpenSearch Serverless capability to stac-server module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,34 @@
 name: Continuous integration
 
 on:
-  pull_request:
   push:
-    branches:
-      main
+    branches: ["main" ]
+  pull_request:
+    branches: ["main"]
 
 jobs:
   update-lambdas:
     runs-on: ubuntu-latest
     env:
       CI: true
-      STAC_SERVER_TAG: v2.2.3
+      STAC_SERVER_TAG: v3.1.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+
       - name: Update stac-server lambdas
+        id: update_stac_lambdas
         run: ./scripts/update-lambdas.sh
+
+      - name: Terraform Init
+        id: tf_init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: tf_validate
+        run: terraform validate -no-color

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+## 2.1.0
+
+### Added
+- Added OpenSearch Serverless capability to stac-server module
+
 ## 2.0.0
 
 ### Added

--- a/default.tfvars
+++ b/default.tfvars
@@ -24,7 +24,7 @@ sns_critical_subscriptions_map  = {}
 ##### APPLICATION VARIABLES ####
 stac_server_inputs  = {
   app_name                                      = "stac_server"
-  version                                       = "v2.2.3"
+  version                                       = "v3.1.0"
   domain_alias                                  = ""
   enable_transactions_extension                 = false
   collection_to_index_mappings                  = ""
@@ -96,6 +96,7 @@ deploy_vpc                          = false
 deploy_vpc_search                   = true
 deploy_log_archive                  = true
 deploy_alarms                       = false
+deploy_stac_opensearch_serverless   = true
 deploy_stac_server                  = true
 deploy_analytics                    = true
 deploy_titiler                      = true

--- a/filmdrop.tf
+++ b/filmdrop.tf
@@ -31,6 +31,7 @@ module "filmdrop" {
   deploy_log_archive                  = var.deploy_log_archive
   deploy_alarms                       = var.deploy_alarms
   deploy_stac_server                  = var.deploy_stac_server
+  deploy_stac_opensearch_serverless   = var.deploy_stac_opensearch_serverless
   deploy_analytics                    = var.deploy_analytics
   deploy_titiler                      = var.deploy_titiler
   deploy_console_ui                   = var.deploy_console_ui

--- a/flop
+++ b/flop
@@ -68,8 +68,8 @@ EOF
                             exit 1
                         fi
                         source $HOME/.nvm/nvm.sh
-                        nvm install v16
-                        nvm use v16
+                        nvm install v18
+                        nvm use v18
                         echo "Building stac-server..."
                         curl -L -f --no-progress-meter -o - "https://github.com/stac-utils/stac-server/archive/refs/tags/${STAC_SERVER_TAG}.tar.gz" | tar -xz
                         cd "$STAC_SERVER_DIR"
@@ -86,7 +86,7 @@ EOF
         destroy|rm)     export stac_opensearch_domain_name=`terraform output stac_opensearch_domain_name`
                         export stac_opensearch_domain_name="${stac_opensearch_domain_name//\"}"
                         export DELETE_OPENSEARCH_DOMAIN="no"
-                        if [[ "$stac_opensearch_domain_name" != "" && "$stac_opensearch_domain_name" != *"Warning"* ]]; then
+                        if [[ "$stac_opensearch_domain_name" != "" && !("$stac_opensearch_domain_name" =~ ".aoss.amazonaws.com") && "$stac_opensearch_domain_name" != *"Warning"* ]]; then
                             echo "We detected a Stac Server OpenSearch Domain $stac_opensearch_domain_name running in flop environment..."
                             echo "Do you really want to destroy the Stac Server OpenSearch domain along with other resources?"
                             echo "There is no undo. Only 'yes' will be accepted to confirm."
@@ -123,8 +123,8 @@ EOF
                             exit 1
                         fi
                         source $HOME/.nvm/nvm.sh
-                        nvm install v16
-                        nvm use v16
+                        nvm install v18
+                        nvm use v18
                         echo "Building stac-server..."
                         curl -L -f --no-progress-meter -o - "https://github.com/stac-utils/stac-server/archive/refs/tags/${STAC_SERVER_TAG}.tar.gz" | tar -xz
                         cd "$STAC_SERVER_DIR"

--- a/inputs.tf
+++ b/inputs.tf
@@ -108,7 +108,7 @@ variable stac_server_inputs {
   })
   default       = {
     app_name                                      = "stac_server"
-    version                                       = "v2.2.3"
+    version                                       = "v3.1.0"
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""
@@ -256,6 +256,12 @@ variable deploy_stac_server {
   type        = bool
   default     = true
   description = "Deploy FilmDrop Stac-Server"
+}
+
+variable deploy_stac_opensearch_serverless {
+  type        = bool
+  default     = true
+  description = "Deploy FilmDrop Stac-Server with OpenSearch Serverless. If False, Stac-server will be deployed with a classic OpenSearch domain."
 }
 
 variable deploy_analytics {

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "stac_server_api" {
   role             = aws_iam_role.stac_api_lambda_role.arn
   handler          = "index.handler"
   source_code_hash = filebase64sha256("${path.module}/lambda/api/api.zip")
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs18.x"
   timeout          = var.api_lambda_timeout
   memory_size      = var.api_lambda_memory
 
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "stac_server_api" {
       OPENSEARCH_HOST = (
         var.opensearch_host != ""
         ? var.opensearch_host
-        : aws_opensearch_domain.stac_server_opensearch_domain.endpoint
+        : local.opensearch_endpoint
       )
       ENABLE_TRANSACTIONS_EXTENSION = var.enable_transactions_extension
       STAC_API_ROOTPATH = (
@@ -34,14 +34,18 @@ resource "aws_lambda_function" "stac_server_api" {
         : var.stac_server_pre_hook_lambda_arn
       )
       POST_HOOK                        = var.stac_server_post_hook_lambda_arn
-      OPENSEARCH_CREDENTIALS_SECRET_ID = aws_secretsmanager_secret.opensearch_stac_user_password_secret.arn
+      OPENSEARCH_CREDENTIALS_SECRET_ID = var.deploy_stac_opensearch_serverless ? "" : aws_secretsmanager_secret.opensearch_stac_user_password_secret.arn
       COLLECTION_TO_INDEX_MAPPINGS     = var.collection_to_index_mappings
     }
   }
 
-  vpc_config {
-    subnet_ids         = var.vpc_subnet_ids
-    security_group_ids = var.vpc_security_group_ids
+  dynamic "vpc_config" {
+    for_each = { for i, j in [var.deploy_stac_opensearch_serverless] : i => j if var.deploy_stac_opensearch_serverless != true }
+
+    content {
+      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids = var.vpc_security_group_ids
+    }
   }
 }
 

--- a/modules/stac-server/api_auth.tf
+++ b/modules/stac-server/api_auth.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "stac_server_api_auth_pre_hook" {
   role             = aws_iam_role.stac_api_lambda_role.arn
   handler          = "index.handler"
   source_code_hash = filebase64sha256("${path.module}/lambda/pre-hook/pre-hook.zip")
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs18.x"
   timeout          = var.pre_hook_lambda_timeout
   memory_size      = var.pre_hook_lambda_memory
 
@@ -16,9 +16,13 @@ resource "aws_lambda_function" "stac_server_api_auth_pre_hook" {
     }
   }
 
-  vpc_config {
-    subnet_ids         = var.vpc_subnet_ids
-    security_group_ids = var.vpc_security_group_ids
+  dynamic "vpc_config" {
+    for_each = { for i, j in [var.deploy_stac_opensearch_serverless] : i => j if var.deploy_stac_opensearch_serverless != true }
+
+    content {
+      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids = var.vpc_security_group_ids
+    }
   }
 }
 

--- a/modules/stac-server/data.tf
+++ b/modules/stac-server/data.tf
@@ -18,3 +18,9 @@ resource "random_string" "user_init_lambda_zip_poke" {
   length  = 16
   special = false
 }
+
+locals {
+  name_prefix         = "fd-${var.project_name}-${var.stac_api_stage}"
+  opensearch_endpoint = var.deploy_stac_opensearch_serverless ? aws_opensearchserverless_collection.stac_server_opensearch_serverless_collection[0].collection_endpoint : aws_opensearch_domain.stac_server_opensearch_domain[0].endpoint
+  opensearch_domain   = var.deploy_stac_opensearch_serverless ? aws_opensearchserverless_collection.stac_server_opensearch_serverless_collection[0].dashboard_endpoint : aws_opensearch_domain.stac_server_opensearch_domain[0].domain_name
+}

--- a/modules/stac-server/iam.tf
+++ b/modules/stac-server/iam.tf
@@ -63,6 +63,16 @@ locals {
         Effect   = "Allow"
       },
       {
+        Action   = ["kms:*"]
+        Resource = "*"
+        Effect   = "Allow"
+      },
+      {
+        Action   = ["aoss:*"]
+        Resource = "*"
+        Effect   = "Allow"
+      },
+      {
         Action   = ["secretsmanager:*"]
         Resource = "*"
         Effect   = "Allow"

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "stac_server_ingest" {
   role                           = aws_iam_role.stac_api_lambda_role.arn
   handler                        = "index.handler"
   source_code_hash               = filebase64sha256("${path.module}/lambda/ingest/ingest.zip")
-  runtime                        = "nodejs16.x"
+  runtime                        = "nodejs18.x"
   timeout                        = var.ingest_lambda_timeout
   memory_size                    = var.ingest_lambda_memory
   reserved_concurrent_executions = var.reserved_concurrent_executions
@@ -13,15 +13,19 @@ resource "aws_lambda_function" "stac_server_ingest" {
   environment {
     variables = {
       LOG_LEVEL                        = var.log_level
-      OPENSEARCH_HOST                  = var.opensearch_host != "" ? var.opensearch_host : aws_opensearch_domain.stac_server_opensearch_domain.endpoint
-      OPENSEARCH_CREDENTIALS_SECRET_ID = aws_secretsmanager_secret.opensearch_stac_user_password_secret.arn
+      OPENSEARCH_HOST                  = var.opensearch_host != "" ? var.opensearch_host : local.opensearch_endpoint
+      OPENSEARCH_CREDENTIALS_SECRET_ID = var.deploy_stac_opensearch_serverless ? "" : aws_secretsmanager_secret.opensearch_stac_user_password_secret.arn
       COLLECTION_TO_INDEX_MAPPINGS     = var.collection_to_index_mappings
     }
   }
 
-  vpc_config {
-    subnet_ids         = var.vpc_subnet_ids
-    security_group_ids = var.vpc_security_group_ids
+  dynamic "vpc_config" {
+    for_each = { for i, j in [var.deploy_stac_opensearch_serverless] : i => j if var.deploy_stac_opensearch_serverless != true }
+
+    content {
+      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids = var.vpc_security_group_ids
+    }
   }
 }
 
@@ -98,7 +102,7 @@ resource "aws_lambda_permission" "stac_server_ingest_sqs_lambda_permission" {
 resource "null_resource" "stac_server_ingest_create_indices" {
   triggers = {
     stac_server_ingest = aws_lambda_function.stac_server_ingest.function_name
-    opensearch_host    = var.opensearch_host != "" ? var.opensearch_host : aws_opensearch_domain.stac_server_opensearch_domain.endpoint
+    opensearch_host    = var.opensearch_host != "" ? var.opensearch_host : var.deploy_stac_opensearch_serverless ? aws_opensearchserverless_collection.stac_server_opensearch_serverless_collection[0].collection_endpoint : aws_opensearch_domain.stac_server_opensearch_domain[0].endpoint
   }
 
   provisioner "local-exec" {

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -305,6 +305,8 @@ variable "opensearch_cluster_dedicated_master_count" {
   default     = 3
 }
 
-locals {
-  name_prefix = "fd-${var.project_name}-${var.stac_api_stage}"
+variable deploy_stac_opensearch_serverless {
+  type        = bool
+  default     = true
+  description = "Deploy FilmDrop Stac-Server with OpenSearch Serverless. If False, Stac-server will be deployed with a classic OpenSearch domain."
 }

--- a/modules/stac-server/opensearch_serverless.tf
+++ b/modules/stac-server/opensearch_serverless.tf
@@ -1,0 +1,97 @@
+resource "aws_opensearchserverless_security_policy" "stac_server_opensearch_serverless_encryption_policy" {
+  count   = var.deploy_stac_opensearch_serverless ? 1 : 0
+  name    = lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-ep" : var.opensearch_stac_server_domain_name_override)
+  type    = "encryption"
+  policy  = jsonencode({
+    "Rules" = [
+      {
+        "Resource" = [
+          "collection/${lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)}"
+        ],
+        "ResourceType" = "collection"
+      }
+    ],
+    "AWSOwnedKey" = true
+  })
+}
+
+resource "aws_opensearchserverless_security_policy" "stac_server_opensearch_serverless_network_policy" {
+  count   = var.deploy_stac_opensearch_serverless ? 1 : 0
+  name    = lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-np" : var.opensearch_stac_server_domain_name_override)
+  type    = "network"
+  policy  = jsonencode([
+    {
+      Description = "Public access for collection endpoint",
+      Rules = [
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/${lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)}"
+          ]
+        }
+      ],
+      AllowFromPublic = true,
+    },
+    {
+      Description = "Public access for dashboards",
+      Rules = [
+        {
+          ResourceType = "dashboard"
+          Resource = [
+            "collection/${lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)}"
+          ]
+        }
+      ],
+      AllowFromPublic = true
+    }
+  ])
+}
+
+resource "aws_opensearchserverless_access_policy" "stac_server_opensearch_serverless_access_policy" {
+  count   = var.deploy_stac_opensearch_serverless ? 1 : 0
+  name    = lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-ap" : var.opensearch_stac_server_domain_name_override)
+  type    = "data"
+  policy  = jsonencode([
+    {
+      Rules = [
+        {
+          ResourceType = "index",
+          Resource = [
+            "index/${lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)}/*"
+          ],
+          Permission = [
+            "aoss:*"
+          ]
+        },
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/${lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)}"
+          ],
+          Permission = [
+            "aoss:*"
+          ]
+        }
+      ],
+      Principal = [
+        data.aws_caller_identity.current.arn,
+        aws_iam_role.stac_api_gw_role.arn
+      ]
+    }
+  ])
+
+  lifecycle {
+    ignore_changes = [policy]
+  }
+}
+
+resource "aws_opensearchserverless_collection" "stac_server_opensearch_serverless_collection" {
+  count   = var.deploy_stac_opensearch_serverless ? 1 : 0
+  name    = lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)
+
+  depends_on = [
+    aws_opensearchserverless_security_policy.stac_server_opensearch_serverless_encryption_policy,
+    aws_opensearchserverless_security_policy.stac_server_opensearch_serverless_network_policy,
+    aws_opensearchserverless_access_policy.stac_server_opensearch_serverless_access_policy
+  ]
+}

--- a/modules/stac-server/outputs.tf
+++ b/modules/stac-server/outputs.tf
@@ -1,9 +1,9 @@
 output "stac_server_opensearch_domain" {
-  value = aws_opensearch_domain.stac_server_opensearch_domain.domain_name
+  value = local.opensearch_domain
 }
 
 output "stac_server_opensearch_endpoint" {
-  value = aws_opensearch_domain.stac_server_opensearch_domain.endpoint
+  value = local.opensearch_endpoint
 }
 
 output "stac_server_api_domain_name" {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -108,7 +108,7 @@ variable stac_server_inputs {
   })
   default       = {
     app_name                                      = "stac_server"
-    version                                       = "v2.2.3"
+    version                                       = "v3.1.0"
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""
@@ -292,6 +292,12 @@ variable deploy_sample_data_bucket {
   type        = bool
   default     = false
   description = "Deploy FilmDrop STAC sample data bucket"
+}
+
+variable deploy_stac_opensearch_serverless {
+  type        = bool
+  default     = true
+  description = "Deploy FilmDrop Stac-Server with OpenSearch Serverless. If False, Stac-server will be deployed with a classic OpenSearch domain."
 }
 
 variable project_sample_data_bucket_name {

--- a/profiles/core/main.tf
+++ b/profiles/core/main.tf
@@ -36,15 +36,16 @@ module "stac-server" {
     aws.east = aws.east
   }
 
-  vpc_id                  = module.base_infra.vpc_id
-  private_subnet_ids      = module.base_infra.private_subnet_ids
-  security_group_id       = module.base_infra.security_group_id
-  vpc_cidr                = module.base_infra.vpc_cidr
-  environment             = var.environment
-  stac_server_inputs      = var.stac_server_inputs
-  project_name            = var.project_name
-  s3_logs_archive_bucket  = module.base_infra.s3_logs_archive_bucket
-  domain_zone             = var.domain_zone
+  vpc_id                            = module.base_infra.vpc_id
+  private_subnet_ids                = module.base_infra.private_subnet_ids
+  security_group_id                 = module.base_infra.security_group_id
+  vpc_cidr                          = module.base_infra.vpc_cidr
+  environment                       = var.environment
+  stac_server_inputs                = var.stac_server_inputs
+  project_name                      = var.project_name
+  s3_logs_archive_bucket            = module.base_infra.s3_logs_archive_bucket
+  domain_zone                       = var.domain_zone
+  deploy_stac_opensearch_serverless = var.deploy_stac_opensearch_serverless
 
   depends_on = [
     module.setup

--- a/profiles/setup/inputs.tf
+++ b/profiles/setup/inputs.tf
@@ -1,7 +1,7 @@
 variable stac_server_version {
   description = "STAC Server version"
   type        = string
-  default     = "v2.2.3" 
+  default     = "v3.1.0"
 }
 
 variable deploy_local_stac_server_artifacts {

--- a/profiles/setup/stac_server_local_setup.tf
+++ b/profiles/setup/stac_server_local_setup.tf
@@ -12,8 +12,8 @@ resource "null_resource" "stac_server_local_artifact_setup" {
 export STAC_SERVER_TAG=${var.stac_server_version}
 export STAC_SERVER_DIR="stac-server-$${STAC_SERVER_TAG:1}"
 source $HOME/.nvm/nvm.sh
-nvm install v16
-nvm use v16
+nvm install v18
+nvm use v18
 echo "Building stac-server..."
 curl -L -f --no-progress-meter -o - "https://github.com/stac-utils/stac-server/archive/refs/tags/$${STAC_SERVER_TAG}.tar.gz" | tar -xz
 cd "$STAC_SERVER_DIR"

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -56,7 +56,7 @@ variable stac_server_inputs {
   })
   default       = {
     app_name                                      = "stac_server"
-    version                                       = "v2.2.3"
+    version                                       = "v3.1.0"
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""
@@ -98,4 +98,10 @@ variable "log_bucket_domain_name" {
   description = "Domain Name of existing CloudFront Distribution Logging bucket"
   type        = string
   default     = ""
+}
+
+variable deploy_stac_opensearch_serverless {
+  type        = bool
+  default     = true
+  description = "Deploy FilmDrop Stac-Server with OpenSearch Serverless. If False, Stac-server will be deployed with a classic OpenSearch domain."
 }

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -17,6 +17,7 @@ module "stac-server" {
   opensearch_ebs_volume_size                  = var.stac_server_inputs.opensearch_ebs_volume_size
   project_name                                = var.project_name
   stac_server_s3_bucket_arns                  = var.stac_server_inputs.stac_server_and_titiler_s3_arns
+  deploy_stac_opensearch_serverless           = var.deploy_stac_opensearch_serverless
 }
 
 module "cloudfront_api_gateway_endpoint" {
@@ -39,4 +40,3 @@ module "cloudfront_api_gateway_endpoint" {
   log_bucket_domain_name        = var.log_bucket_domain_name
   filmdrop_archive_bucket_name  = var.s3_logs_archive_bucket
 }
-

--- a/profiles/stac-server/outputs.tf
+++ b/profiles/stac-server/outputs.tf
@@ -7,5 +7,5 @@ output "stac_opensearch_domain_name" {
 }
 
 output "stac_opensearch_endpoint" {
-  value = "https://${module.stac-server.stac_server_opensearch_endpoint}"
+  value = module.stac-server.stac_server_opensearch_endpoint
 }

--- a/scripts/update-lambdas.sh
+++ b/scripts/update-lambdas.sh
@@ -4,11 +4,11 @@
 #
 # Usage:
 #
-#     ./scripts/update-lambdas.sh v2.2.3
+#     ./scripts/update-lambdas.sh v3.1.0
 #
 # or
 #
-#     export STAC_SERVER_TAG=v2.2.3
+#     export STAC_SERVER_TAG=v3.1.0
 #     ./scripts/update-lambdas.sh
 
 set -e


### PR DESCRIPTION
Description
- Adding OpenSearch Serverless capability to stac-server module and a flag to switch between OpenSearch Domain and OpenSearch Serverless
- Added a Terraform validation github action
- Updated stac-server lambdas to node 18 and default stac-server version to v3.1.0