### PR TITLE
Make cloudfront deployment optional for stac-server, with a parameter in the stac_server_inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+## 2.2.0
+
+### Added
+- Added capability for optional CloudFront deployment for stac-server, with a parameter in the stac_server_inputs
+
 ## 2.1.0
 
 ### Added

--- a/default.tfvars
+++ b/default.tfvars
@@ -25,6 +25,7 @@ sns_critical_subscriptions_map  = {}
 stac_server_inputs  = {
   app_name                                      = "stac_server"
   version                                       = "v3.2.0"
+  deploy_cloudfront                             = true
   domain_alias                                  = ""
   enable_transactions_extension                 = false
   collection_to_index_mappings                  = ""

--- a/inputs.tf
+++ b/inputs.tf
@@ -93,6 +93,7 @@ variable stac_server_inputs {
   type        = object({
     app_name                                      = string
     version                                       = string
+    deploy_cloudfront                             = bool
     domain_alias                                  = string
     enable_transactions_extension                 = bool
     collection_to_index_mappings                  = string
@@ -109,6 +110,7 @@ variable stac_server_inputs {
   default       = {
     app_name                                      = "stac_server"
     version                                       = "v3.2.0"
+    deploy_cloudfront                             = true
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -93,6 +93,7 @@ variable stac_server_inputs {
   type        = object({
     app_name                                      = string
     version                                       = string
+    deploy_cloudfront                             = bool
     domain_alias                                  = string
     enable_transactions_extension                 = bool
     collection_to_index_mappings                  = string
@@ -109,6 +110,7 @@ variable stac_server_inputs {
   default       = {
     app_name                                      = "stac_server"
     version                                       = "v3.2.0"
+    deploy_cloudfront                             = true
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -41,6 +41,7 @@ variable stac_server_inputs {
   type        = object({
     app_name                                      = string
     version                                       = string
+    deploy_cloudfront                             = bool
     domain_alias                                  = string
     enable_transactions_extension                 = bool
     collection_to_index_mappings                  = string
@@ -57,6 +58,7 @@ variable stac_server_inputs {
   default       = {
     app_name                                      = "stac_server"
     version                                       = "v3.2.0"
+    deploy_cloudfront                             = true
     domain_alias                                  = ""
     enable_transactions_extension                 = false
     collection_to_index_mappings                  = ""

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -17,11 +17,12 @@ module "stac-server" {
   opensearch_ebs_volume_size                  = var.stac_server_inputs.opensearch_ebs_volume_size
   project_name                                = var.project_name
   stac_server_s3_bucket_arns                  = var.stac_server_inputs.stac_server_and_titiler_s3_arns
-  deploy_stac_server_opensearch_serverless           = var.deploy_stac_server_opensearch_serverless
+  deploy_stac_server_opensearch_serverless    = var.deploy_stac_server_opensearch_serverless
 }
 
 module "cloudfront_api_gateway_endpoint" {
-  source = "../../modules/cloudfront/apigw_endpoint"
+  count     = var.stac_server_inputs.deploy_cloudfront ? 1 : 0
+  source    = "../../modules/cloudfront/apigw_endpoint"
 
   providers = {
     aws.east = aws.east

--- a/profiles/stac-server/outputs.tf
+++ b/profiles/stac-server/outputs.tf
@@ -1,5 +1,5 @@
 output "stac_url" {
-  value = "https://${module.cloudfront_api_gateway_endpoint.domain_name}"
+  value = var.stac_server_inputs.deploy_cloudfront ? "https://${module.cloudfront_api_gateway_endpoint[0].domain_name}" : "https://${module.stac-server.stac_server_api_domain_name}${module.stac-server.stac_server_api_path}"
 }
 
 output "stac_opensearch_domain_name" {


### PR DESCRIPTION
## Description

1. Added capability for optional CloudFront deployment for stac-server, with a parameter in the stac_server_inputs