### PR TITLE
update setup tflint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.3"
-      - uses: terraform-linters/setup-tflint@v3
+      - uses: terraform-linters/setup-tflint@v4
         with:
           tflint_version: "v0.49.0"
       - uses: actions/setup-python@v5

--- a/.github/workflows/deploy-manual-tests.yml
+++ b/.github/workflows/deploy-manual-tests.yml
@@ -169,7 +169,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.3"
-      - uses: terraform-linters/setup-tflint@v3
+      - uses: terraform-linters/setup-tflint@v4
         with:
           tflint_version: "v0.49.0"
       - uses: actions/setup-python@v5

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -171,7 +171,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.3"
-      - uses: terraform-linters/setup-tflint@v3
+      - uses: terraform-linters/setup-tflint@v4
         with:
           tflint_version: "v0.49.0"
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.22.0] - 2024-05-14
 
 ### Added
 


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. update to terraform-linters/setup-tflint@v4, which uses node 20 instead of node 16

## Testing

This change was validated by the following observations:

1. CI tests

## Checklist

- [ ] I have deployed and validated this change
- [ ] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
