### PR TITLE
Updates to match a previous change to private/public subnets_az_to_id_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Access-Control-Allow-Methods: `CORS_METHODS`
   - Access-Control-Allow-Headers: `CORS_HEADERS`
 
+### Changed
+
+- private_subnets_az_to_id_map now correctly using ID as the map value instead of previous cidr_block
+- public_subnets_az_to_id_map now correctly using ID as the map value instead of previous cidr_block
+
+### Removed
+
+- VPC and subnets are no longer created by the FD VPC module, since IDs must now be provided for preexisting resources.  If `deploy_vpc` was set to `true` on a previous terrform apply, then this update will to attempt to delete the VPC and subnets, which will fail due to resource dependencies.  The TF state will need to be manually updated to remove these references without deleting the underlying AWS resources.
+
 ## [2.21.0] - 2024-05-10
 
 ### Changed

--- a/modules/base_infra/vpc_infra/igw.tf
+++ b/modules/base_infra/vpc_infra/igw.tf
@@ -1,6 +1,6 @@
 # Creates Internet Gateway, with a public route table, and a default route
 resource "aws_internet_gateway" "igw" {
-  vpc_id = aws_vpc.filmdrop_vpc.id
+  vpc_id = data.aws_vpc.filmdrop_vpc.id
 
   tags = {
     Name = "${local.name_prefix}-internet-gateway"
@@ -8,7 +8,7 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_route_table" "public_route_table" {
-  vpc_id = aws_vpc.filmdrop_vpc.id
+  vpc_id = data.aws_vpc.filmdrop_vpc.id
 
   tags = {
     Name = "${local.name_prefix}-public-route-table"
@@ -22,7 +22,7 @@ resource "aws_route" "public_default_route" {
 }
 
 resource "aws_route_table_association" "public_route_table_associations" {
-  for_each = aws_subnet.public_subnets
+  for_each = data.aws_subnet.public_subnets
 
   subnet_id      = each.value.id
   route_table_id = aws_route_table.public_route_table.id

--- a/modules/base_infra/vpc_infra/ngw.tf
+++ b/modules/base_infra/vpc_infra/ngw.tf
@@ -9,9 +9,9 @@ resource "aws_eip" "eips" {
 }
 
 resource "aws_nat_gateway" "ngws" {
-  for_each = aws_subnet.public_subnets
+  for_each = data.aws_subnet.public_subnets
 
-  allocation_id = element(values(aws_eip.eips)[*].id, index(values(aws_subnet.public_subnets)[*].id, each.value.id))
+  allocation_id = element(values(aws_eip.eips)[*].id, index(values(data.aws_subnet.public_subnets)[*].id, each.value.id))
   subnet_id     = each.value.id
   tags = {
     Name = "${local.name_prefix}-nat-gateway-${each.value.id}"
@@ -23,9 +23,9 @@ resource "aws_nat_gateway" "ngws" {
 # We need a different route table per subnet, because each subnet
 # may point to a different NAT Gateway for high availability
 resource "aws_route_table" "private_route_tables" {
-  for_each = aws_subnet.private_subnets
+  for_each = data.aws_subnet.private_subnets
 
-  vpc_id = aws_vpc.filmdrop_vpc.id
+  vpc_id = data.aws_vpc.filmdrop_vpc.id
 
   tags = {
     Name = "${local.name_prefix}-private-route-table-${each.value.id}"
@@ -35,10 +35,10 @@ resource "aws_route_table" "private_route_tables" {
 }
 
 resource "aws_route_table_association" "private_route_table_associations" {
-  for_each = aws_subnet.private_subnets
+  for_each = data.aws_subnet.private_subnets
 
   subnet_id      = each.value.id
-  route_table_id = element(values(aws_route_table.private_route_tables)[*].id, index(values(aws_subnet.private_subnets)[*].id, each.value.id))
+  route_table_id = element(values(aws_route_table.private_route_tables)[*].id, index(values(data.aws_subnet.private_subnets)[*].id, each.value.id))
 }
 
 
@@ -47,9 +47,9 @@ resource "aws_route_table_association" "private_route_table_associations" {
 # and the number of Public Subnets may not be equal to the number of Private Subnets.
 # This means that the number of NAT Gateways may not be equal to the number of Private Route Tables.
 resource "aws_route" "private_subnet_default_routes" {
-  for_each = aws_subnet.private_subnets
+  for_each = data.aws_subnet.private_subnets
 
-  route_table_id         = element(values(aws_route_table.private_route_tables)[*].id, index(values(aws_subnet.private_subnets)[*].id, each.value.id))
-  nat_gateway_id         = element(values(aws_nat_gateway.ngws)[*].id, index(values(aws_subnet.private_subnets)[*].id, each.value.id) % length(values(aws_subnet.public_subnets)[*].id))
+  route_table_id         = element(values(aws_route_table.private_route_tables)[*].id, index(values(data.aws_subnet.private_subnets)[*].id, each.value.id))
+  nat_gateway_id         = element(values(aws_nat_gateway.ngws)[*].id, index(values(data.aws_subnet.private_subnets)[*].id, each.value.id) % length(values(data.aws_subnet.public_subnets)[*].id))
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/modules/base_infra/vpc_infra/outputs.tf
+++ b/modules/base_infra/vpc_infra/outputs.tf
@@ -11,17 +11,17 @@ output "eip_ids" {
 
 output "vpc_id" {
   description = "FilmDrop VPC ID"
-  value       = aws_vpc.filmdrop_vpc.id
+  value       = data.aws_vpc.filmdrop_vpc.id
 }
 
 output "private_subnet_ids" {
   description = "List of FilmDrop Private Subnet IDs"
-  value       = values(aws_subnet.private_subnets)[*].id
+  value       = values(data.aws_subnet.private_subnets)[*].id
 }
 
 output "public_subnet_ids" {
   description = "List of FilmDrop Public Subnet IDs"
-  value       = values(aws_subnet.public_subnets)[*].id
+  value       = values(data.aws_subnet.public_subnets)[*].id
 }
 
 output "private_avaliability_zones" {

--- a/modules/base_infra/vpc_infra/vpc_endpoints.tf
+++ b/modules/base_infra/vpc_infra/vpc_endpoints.tf
@@ -3,7 +3,7 @@ module "gateway_endpoints" {
 
   for_each = toset(var.gateway_endpoints_list)
 
-  vpc_id          = aws_vpc.filmdrop_vpc.id
+  vpc_id          = data.aws_vpc.filmdrop_vpc.id
   service_name    = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
   route_table_ids = concat([aws_route_table.public_route_table.id], values(aws_route_table.private_route_tables)[*].id)
 }
@@ -13,9 +13,9 @@ module "interface_endpoints" {
 
   for_each = toset(var.interface_endpoints_list)
 
-  vpc_id              = aws_vpc.filmdrop_vpc.id
+  vpc_id              = data.aws_vpc.filmdrop_vpc.id
   service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
   security_group_ids  = [aws_security_group.filmdrop_vpc_default_sg.id]
-  subnet_ids          = values(aws_subnet.private_subnets)[*].id
+  subnet_ids          = values(data.aws_subnet.private_subnets)[*].id
   private_dns_enabled = true
 }

--- a/modules/base_infra/vpc_infra/vpc_security_group.tf
+++ b/modules/base_infra/vpc_infra/vpc_security_group.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "filmdrop_vpc_default_sg" {
   name        = "${local.name_prefix}-sg"
   description = "Default Security Group for the FilmDrop ${var.project_name} ${var.environment} VPC"
-  vpc_id      = aws_vpc.filmdrop_vpc.id
+  vpc_id      = data.aws_vpc.filmdrop_vpc.id
 }
 
 # Allows any inbound traffic coming from within the FilmDrop VPC

--- a/modules/base_infra/vpc_infra/vpc_subnets.tf
+++ b/modules/base_infra/vpc_infra/vpc_subnets.tf
@@ -4,12 +4,12 @@ data "aws_vpc" "filmdrop_vpc" {
 
 data "aws_subnet" "public_subnets" {
   for_each = var.public_subnets_az_to_id_map
-  id = each.value
+  id       = each.value
 }
 
 data "aws_subnet" "private_subnets" {
   for_each = var.private_subnets_az_to_id_map
-  id = each.value
+  id       = each.value
 }
 
 # Set up default DHCP options for DNS resolution in FilmDrop VPC - defaults to AmazonProvidedDNS

--- a/modules/base_infra/vpc_infra/vpc_subnets.tf
+++ b/modules/base_infra/vpc_infra/vpc_subnets.tf
@@ -1,36 +1,15 @@
-resource "aws_vpc" "filmdrop_vpc" {
-  cidr_block           = var.vpc_cidr
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = {
-    Name = "${local.name_prefix}-vpc"
-  }
+data "aws_vpc" "filmdrop_vpc" {
+  cidr_block = var.vpc_cidr
 }
 
-resource "aws_subnet" "public_subnets" {
+data "aws_subnet" "public_subnets" {
   for_each = var.public_subnets_az_to_id_map
-
-  vpc_id            = aws_vpc.filmdrop_vpc.id
-  cidr_block        = each.value
-  availability_zone = each.key
-
-  tags = {
-    Name = "${local.name_prefix}-public-subnet-${each.key}"
-  }
+  id = each.value
 }
 
-resource "aws_subnet" "private_subnets" {
+data "aws_subnet" "private_subnets" {
   for_each = var.private_subnets_az_to_id_map
-
-  vpc_id            = aws_vpc.filmdrop_vpc.id
-  cidr_block        = each.value
-  availability_zone = each.key
-
-  tags = {
-    Name = "${local.name_prefix}-private-subnet-${each.key}"
-  }
-
+  id = each.value
 }
 
 # Set up default DHCP options for DNS resolution in FilmDrop VPC - defaults to AmazonProvidedDNS
@@ -40,7 +19,7 @@ resource "aws_vpc_dhcp_options" "vpc_dhcp_options" {
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {
-  vpc_id          = aws_vpc.filmdrop_vpc.id
+  vpc_id          = data.aws_vpc.filmdrop_vpc.id
   dhcp_options_id = aws_vpc_dhcp_options.vpc_dhcp_options.id
 }
 
@@ -52,10 +31,10 @@ resource "aws_flow_log" "filmdrop_vpc_flow_logs_to_s3" {
   log_format               = var.log_format
   max_aggregation_interval = var.max_aggregation_interval
   traffic_type             = var.traffic_type
-  vpc_id                   = aws_vpc.filmdrop_vpc.id
+  vpc_id                   = data.aws_vpc.filmdrop_vpc.id
 
   tags = {
-    Name = "${local.name_prefix}-flow-logs-${aws_vpc.filmdrop_vpc.id}"
+    Name = "${local.name_prefix}-flow-logs-${data.aws_vpc.filmdrop_vpc.id}"
   }
 }
 


### PR DESCRIPTION
which was previously mapping subnet_az to cidr_block.  This has the side effect of no longer creating the VPC and subnets in the VPC module.  The module consumer must now create the VPC and subnets prior to using the FD vpc module, so that IDs can be provided.

## Related issue(s)

-

## Proposed Changes

1. private_subnets_az_to_id_map now correctly using ID as the map value instead of previous cidr_block
2. public_subnets_az_to_id_map now correctly using ID as the map value instead of previous cidr_block
3. VPC and subnets are no longer created by the FD VPC module, since IDs must be provided for preexisting resources

## Testing

This change was validated by the following observations:

1. using the internal vpc-module-test project for testing

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary
