### PR TITLE
Allow 7 instead of 5 characters for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.23.0] - 2024-05-16
 
+### Changed
+
+- Allow 7 instead of 5 characters for `environment`
+
 ### Fixed
 
 - Fixed filmdrop built-in vpc output references and mappings

--- a/inputs.tf
+++ b/inputs.tf
@@ -2,8 +2,8 @@ variable "environment" {
   description = "Project environment."
   type        = string
   validation {
-    condition     = length(var.environment) <= 5
-    error_message = "The environment value must be 5 or fewer characters."
+    condition     = length(var.environment) <= 7
+    error_message = "The environment value must be 7 or fewer characters."
   }
 }
 


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. Allow 7 instead of 5 characters for `environment`

## Testing

This change was validated by the following observations:

1. n/a

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
