### PR TITLE
Fix console-ui input defaults so it will validate even if tfvars are not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Fixed
+
+- console-ui module will validate now even if no tfvars file is provided
+
 ## [2.23.0] - 2024-05-16
 
 ### Changed

--- a/profiles/console-ui/main.tf
+++ b/profiles/console-ui/main.tf
@@ -8,9 +8,9 @@ module "console-ui" {
   filmdrop_ui_release    = var.console_ui_inputs.filmdrop_ui_release
   console_ui_bucket_name = var.console_ui_inputs.deploy_cloudfront ? module.cloudfront_s3_website[0].content_bucket_name : module.content_website[0].content_bucket
 
-  filmdrop_ui_config    = filebase64(var.console_ui_inputs.filmdrop_ui_config_file)
+  filmdrop_ui_config    = var.console_ui_inputs.filmdrop_ui_config_file != "" ? filebase64(var.console_ui_inputs.filmdrop_ui_config_file) : "bm9uZQo=" # None
   filmdrop_ui_logo_file = var.console_ui_inputs.filmdrop_ui_logo_file
-  filmdrop_ui_logo      = filebase64(var.console_ui_inputs.filmdrop_ui_logo_file)
+  filmdrop_ui_logo      = var.console_ui_inputs.filmdrop_ui_logo != "" ? var.console_ui_inputs.filmdrop_ui_logo : filebase64(var.console_ui_inputs.filmdrop_ui_logo_file)
 }
 
 module "cloudfront_s3_website" {


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. Changed the defaults for the console-ui filmdrop_ui_config and filmdrop_ui_logo

## Testing

This change was validated by the following observations:

1. made the change in a downstream project and ran `terraform validate`

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
