### PR TITLE
set defaults for filmdrop_ui_config_file and filmdrop_ui_logo_file

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -326,8 +326,8 @@ variable "console_ui_inputs" {
       }
     ]
     filmdrop_ui_release     = "v5.3.0"
-    filmdrop_ui_config_file = ""
-    filmdrop_ui_logo_file   = ""
+    filmdrop_ui_config_file = "./profiles/console-ui/default-config/config.dev.json"
+    filmdrop_ui_logo_file   = "./profiles/console-ui/default-config/logo.png"
     filmdrop_ui_logo        = "bm9uZQo=" # Base64: 'none'
     auth_function = {
       cf_function_name             = ""

--- a/profiles/console-ui/inputs.tf
+++ b/profiles/console-ui/inputs.tf
@@ -71,8 +71,8 @@ variable "console_ui_inputs" {
       }
     ]
     filmdrop_ui_release     = "v5.3.0"
-    filmdrop_ui_config_file = ""
-    filmdrop_ui_logo_file   = ""
+    filmdrop_ui_config_file = "./default-config/config.dev.json"
+    filmdrop_ui_logo_file   = "./default-config/logo.png"
     filmdrop_ui_logo        = "bm9uZQo=" # Base64: 'none'
     auth_function = {
       cf_function_name             = ""

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -326,8 +326,8 @@ variable "console_ui_inputs" {
       }
     ]
     filmdrop_ui_release     = "v5.3.0"
-    filmdrop_ui_config_file = ""
-    filmdrop_ui_logo_file   = ""
+    filmdrop_ui_config_file = "../console-ui/default-config/config.dev.json"
+    filmdrop_ui_logo_file   = "../console-ui/default-config/logo.png"
     filmdrop_ui_logo        = "bm9uZQo=" # Base64: 'none'
     auth_function = {
       cf_function_name             = ""


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. set defaults for filmdrop_ui_config_file and filmdrop_ui_logo_file

## Testing

This change was validated by the following observations:

1. running tflint 

## Checklist

- [X] I have deployed and validated this change
- [ ] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
