### PR TITLE
update default stac-server to 3.8.0 and opensearch to 2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
+- Default to stac-server 3.8.0 and OpenSearch 2.13
+
+## 2.26.0 - 2024-05-29
+
+## Changed
+
 - For both `stac_server_inputs` and `titiler_inputs`, renamed
   `stac_server_and_titiler_s3_arns` to `authorized_s3_arns`.
 - `private_subnets_az_to_id_map` now correctly using ID as the map value instead of previous cidr_block

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -22,7 +22,7 @@ sns_critical_subscriptions_map = {}
 ##### APPLICATION VARIABLES ####
 stac_server_inputs = {
   app_name                                    = "stac_server"
-  version                                     = "v3.7.0"
+  version                                     = "v3.8.0"
   deploy_cloudfront                           = false
   domain_alias                                = ""
   enable_transactions_extension               = false

--- a/default.tfvars
+++ b/default.tfvars
@@ -24,7 +24,7 @@ sns_critical_subscriptions_map = {}
 ##### APPLICATION VARIABLES ####
 stac_server_inputs = {
   app_name                                    = "stac_server"
-  version                                     = "v3.7.0"
+  version                                     = "v3.8.0"
   deploy_cloudfront                           = true
   domain_alias                                = ""
   enable_transactions_extension               = false

--- a/inputs.tf
+++ b/inputs.tf
@@ -137,7 +137,7 @@ variable "stac_server_inputs" {
   })
   default = {
     app_name                                    = "stac_server"
-    version                                     = "v3.7.0"
+    version                                     = "v3.8.0"
     deploy_cloudfront                           = true
     domain_alias                                = ""
     enable_transactions_extension               = false

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -115,7 +115,7 @@ variable "api_rest_type" {
 variable "opensearch_version" {
   description = "OpenSearch version for OpenSearch Domain"
   type        = string
-  default     = "OpenSearch_2.11"
+  default     = "OpenSearch_2.13"
 }
 
 variable "opensearch_cluster_instance_type" {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -137,7 +137,7 @@ variable "stac_server_inputs" {
   })
   default = {
     app_name                                    = "stac_server"
-    version                                     = "v3.7.0"
+    version                                     = "v3.8.0"
     deploy_cloudfront                           = true
     domain_alias                                = ""
     enable_transactions_extension               = false

--- a/profiles/setup/inputs.tf
+++ b/profiles/setup/inputs.tf
@@ -1,7 +1,7 @@
 variable "stac_server_version" {
   description = "STAC Server version"
   type        = string
-  default     = "v3.7.0"
+  default     = "v3.8.0"
 }
 
 variable "deploy_local_stac_server_artifacts" {

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -85,7 +85,7 @@ variable "stac_server_inputs" {
   })
   default = {
     app_name                                    = "stac_server"
-    version                                     = "v3.7.0"
+    version                                     = "v3.8.0"
     deploy_cloudfront                           = true
     domain_alias                                = ""
     enable_transactions_extension               = false


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. update default stac-server to 3.8.0 and opensearch to 2.13

## Testing

This change was validated by the following observations:

1. n/a

## Checklist

- [X] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
