### PR TITLE
Easier Cirrus Workflow Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Cirrus Workflows may now be created without a user-provided State Machine template
+  - Intended for Workflows that are simple sequential executions of Cirrus Tasks
+  - Complex Workflows may still be defined using a State Machine template
+
 ### Changed
 
 ### Fixed

--- a/inputs.tf
+++ b/inputs.tf
@@ -555,12 +555,23 @@ variable "cirrus_inputs" {
     workflows = optional(list(object({
       name                   = string
       non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      default_template_config = optional(object({
+        description = string
+        allow_retry = bool
+        state_sequence = list(object({
+          state_name = optional(string)
+          task_name  = string
+          task_type  = string
+        }))
+      }))
+      custom_template_config = optional(object({
+        filepath = string
+        variables = optional(map(object({
+          task_name = string
+          task_type = string
+          task_attr = string
+        })))
+      }))
     })))
   })
   default = {

--- a/modules/cirrus/inputs.tf
+++ b/modules/cirrus/inputs.tf
@@ -522,62 +522,101 @@ variable "cirrus_workflows" {
         task. This is necessary for granting the Workflow execution role invoke
         permissions on these functions.
 
-      - template_filepath: (required, string) Path to an Amazon State Machine
-        definition template file. The path must be relative to the ROOT module
-        of the Terraform deployment. The template should use valid Amazon States
-        Language syntax; wherever a Cirrus Task resource ARN is needed, a
-        Terraform interpolation sequence (a "$\{...}" without the "\") may be
-        used instead. The variable name does not matter so long as there is a
-        corresponding entry in the "template_variables" argument.
-        Example template snippet:
+      - default_template_config: (optional, object) Used to create an Amazon
+        State Machine by rendering and combining predefined state configurations
+        using outputs from the Cirrus Tasks referenced in 'state_sequence'. If
+        your State Machine is a simple sequential execution of Cirrus Tasks,
+        this config should be preferred over 'custom_template_config' as it
+        removes the need for creating a State Machine definition template.
+        Contents:
+          - description: (required, string) Workflow description
+          - allow_retry: (required, bool) Whether individual states should be
+            retried in the event of a failure.
+          - state_sequence: (required, list[object]) List of Cirrus Tasks that
+            will be executed sequentially.
+            Contents:
+              - task_name: (required, string) Cirrus Task name. Used for getting
+                Task output resource ARNs. Will also be used for the state name
+                if 'state_name' is omitted.
+              - task_type: (required, string) lambda or batch
+              - state_name: (optional, string) State name. Must be unique within
+                the Workflow. In most cases, this can be omitted as 'task_name'
+                is used by default. Useful if you need to call the same Task
+                multiple times within a Workflow.
 
-          "States": {
-            "FirstState": {
-              "Type": "Task",
-              "Resource": "$\{my-task-lambda}",  // REMOVE THE "\"
-              "Next": "SecondState",
-              ...
-            },
+      - custom_template_config: (optional, object) Used to create an Amazon
+        State Machine by rendering a user-provided template with variables that
+        reference Cirrus Task outputs. Useful for complex State Machines that
+        cannot be created using the 'default_template_config' option.
+        Contents:
+          - filepath: (required, string) Path to an Amazon State Machine
+            template definition. The path must be relative to the ROOT module of
+            the Terraform deployment. The template should use valid Amazon State
+            Language syntax; wherever a Cirrus Task resource ARN is needed, a
+            Terraform interpolation sequence (a "$\{...}" without the "\") may
+            be used instead. The variable name does not matter so long as there
+            is a corresponding entry in the "template_variables" argument.
+            Example template snippet:
 
-        Cirrus may deploy and manage several builtin tasks. Resource ARNs for
-        these tasks may be referenced in a Workflow template using a predefined
-        variable name without having to supply a 'template_variable' entry.
-          - If Batch Tasks were created, the following variables may be used:
-            - PRE-BATCH: cirrus-geo pre-batch Lambda function ARN
-            - POST-BATCH: cirrus-geo post-batch Lambda function ARN
+              "States": {
+                "FirstState": {
+                  "Type": "Task",
+                  "Resource": "$\{my-task-lambda}",  // REMOVE THE "\"
+                  "Next": "SecondState",
+                  ...
+                },
 
-      - template_variables: (optional, map[object]) A map of template variable
-        names to their corresponding Cirrus Task attributes. Assuming a Cirrus
-        Task named "my-task" with Lambda config was passed to the 'task' module,
-        the following workflow template variable config:
+            Cirrus may deploy and manage several builtin tasks. Resource ARNs
+            for these tasks may be referenced in a Workflow template using
+            predefined variable names without having to supply a
+            'template_variable' entry.
+              - If Batch Tasks were created, these variables may be used:
+                - PRE-BATCH: cirrus-geo pre-batch Lambda function ARN
+                - POST-BATCH: cirrus-geo post-batch Lambda function ARN
 
-          my-task-lambda = {
-            task_name = "my-task"
-            task_type = "lambda"
-            task_attr = "functon_arn"
-          }
+          - template_variables: (optional, map[object]) Map of template variable
+            names to their corresponding Cirrus Task attributes. Assuming a
+            Cirrus Task named "my-task" with a Lambda config was passed to the
+            'task' module, the following workflow template variable config:
 
-        when used with the example Workflow snippet above would result in the
-        following content after template interpolation:
+              my-task-lambda = {
+                task_name = "my-task"
+                task_type = "lambda"
+                task_attr = "function_arn"
+              }
 
-          "States": {
-            "FirstState": {
-              "Type": "Task",
-              "Resource": "arn:aws:lambda:us-west-2:123456789012:function:my-function",
-              "Next": "SecondState",
-              ...
-            },
+            when used with the example Workflow snippet above, would result in
+            the following content after template interpolation:
+
+              "States": {
+                "FirstState": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:lambda:us-west-2:123456789012:function:my-function",
+                  "Next": "SecondState",
+                  ...
+                },
   DESCRIPTION
 
   type = list(object({
     name                   = string
     non_cirrus_lambda_arns = optional(list(string))
-    template_filepath      = string
-    template_variables = optional(map(object({
-      task_name = string
-      task_type = string
-      task_attr = string
-    })))
+    default_template_config = optional(object({
+      description = string
+      allow_retry = bool
+      state_sequence = list(object({
+        state_name = optional(string)
+        task_name  = string
+        task_type  = string
+      }))
+    }))
+    custom_template_config = optional(object({
+      filepath = string
+      variables = optional(map(object({
+        task_name = string
+        task_type = string
+        task_attr = string
+      })))
+    }))
   }))
 
   default  = []

--- a/modules/cirrus/workflow/templates/batch_state.tftpl
+++ b/modules/cirrus/workflow/templates/batch_state.tftpl
@@ -1,0 +1,106 @@
+"${state_name}": {
+  "Type": "Parallel",
+  "Branches": [{
+    "StartAt": "${state_name}-pre-batch",
+    "States": {
+      "${state_name}-pre-batch": {
+        "Type": "Task",
+        "Resource": "${PRE-BATCH}",
+        %{ if allow_retry }
+        "Retry": [
+          {
+            "ErrorEquals": [
+              "Lambda.TooManyRequestsException",
+              "Lambda.Unknown"
+            ],
+            "IntervalSeconds": 10,
+            "MaxDelaySeconds": 86400,
+            "BackoffRate": 2.0,
+            "MaxAttempts": 20,
+            "JitterStrategy": "FULL"
+          }
+        ],
+        %{ endif }
+        "Next": "${state_name}-batch"
+      },
+      "${state_name}-batch": {
+        "Type": "Task",
+        "Resource": "arn:aws:states:::batch:submitJob.sync",
+        "Parameters": {
+          "JobName": "${state_name}",
+          "JobQueue": "${job_queue_arn}",
+          "JobDefinition": "${job_definition_arn}",
+          "Parameters": {
+            "url.$": "$.url",
+            "url_out.$": "$.url_out"
+          }
+        },
+        %{ if allow_retry }
+        "Retry": [
+          {
+            "ErrorEquals": ["Batch.AWSBatchException"],
+            "IntervalSeconds": 600,
+            "MaxDelaySeconds": 86400,
+            "BackoffRate": 2.0,
+            "MaxAttempts": 20,
+            "JitterStrategy": "FULL"
+          }
+        ],
+        %{ endif }
+        "Catch": [
+          {
+            "ErrorEquals": ["States.ALL"],
+            "ResultPath": "$.error",
+            "Next": "${state_name}-post-batch"
+          }
+        ],
+        "Next": "${state_name}-post-batch"
+      },
+      "${state_name}-post-batch": {
+        "Type": "Task",
+        "Resource": "${POST-BATCH}",
+        %{ if allow_retry }
+        "Retry": [
+          {
+            "ErrorEquals": [
+              "Lambda.TooManyRequestsException",
+              "Lambda.Unknown"
+            ],
+            "IntervalSeconds": 10,
+            "MaxDelaySeconds": 86400,
+            "BackoffRate": 2.0,
+            "MaxAttempts": 20,
+            "JitterStrategy": "FULL"
+          }
+        ],
+        %{ endif }
+        "End": true
+      }
+    }
+  }],
+  "OutputPath": "$[0]",
+  %{ if allow_retry }
+  "Retry": [
+    {
+      "ErrorEquals": ["States.ALL"],
+      "MaxAttempts": 3,
+      "IntervalSeconds": 1200,
+      "MaxDelaySeconds": 86400,
+      "BackoffRate": 2.0,
+      "JitterStrategy": "FULL"
+    }
+  ],
+  %{ endif }
+  "Catch": [
+    {
+      "ErrorEquals": ["States.ALL"],
+      "ResultPath": "$.error",
+      "Next": "failure"
+    }
+  ],
+  %{ if next_or_end != null }
+  "Next": "${next_or_end}"
+  %{ else }
+  "End": true
+  %{ endif }
+},

--- a/modules/cirrus/workflow/templates/default.tftpl
+++ b/modules/cirrus/workflow/templates/default.tftpl
@@ -1,0 +1,12 @@
+{
+  "Comment": "${workflow_description}",
+  "StartAt": "${first_state_name}",
+  "States": {
+    %{ for state_string in state_strings }
+    ${ state_string }
+    %{ endfor }
+    "failure": {
+      "Type": "Fail"
+    }
+  }
+}

--- a/modules/cirrus/workflow/templates/lambda_state.tftpl
+++ b/modules/cirrus/workflow/templates/lambda_state.tftpl
@@ -1,0 +1,31 @@
+"${state_name}": {
+  "Type": "Task",
+  "Resource": "${function_arn}",
+  %{ if allow_retry }
+  "Retry": [
+    {
+      "ErrorEquals": [
+        "Lambda.TooManyRequestsException",
+        "Lambda.Unknown"
+      ],
+      "IntervalSeconds": 10,
+      "MaxDelaySeconds": 86400,
+      "BackoffRate": 2.0,
+      "MaxAttempts": 20,
+      "JitterStrategy": "FULL"
+    }
+  ],
+  %{ endif }
+  "Catch": [
+    {
+      "ErrorEquals": ["States.ALL"],
+      "ResultPath": "$.error",
+      "Next": "failure"
+    }
+  ],
+  %{ if next_or_end != null }
+  "Next": "${next_or_end}"
+  %{ else }
+  "End": true
+  %{ endif }
+},

--- a/profiles/cirrus/inputs.tf
+++ b/profiles/cirrus/inputs.tf
@@ -248,12 +248,23 @@ variable "cirrus_inputs" {
     workflows = optional(list(object({
       name                   = string
       non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      default_template_config = optional(object({
+        description = string
+        allow_retry = bool
+        state_sequence = list(object({
+          state_name = optional(string)
+          task_name  = string
+          task_type  = string
+        }))
+      }))
+      custom_template_config = optional(object({
+        filepath = string
+        variables = optional(map(object({
+          task_name = string
+          task_type = string
+          task_attr = string
+        })))
+      }))
     })))
   })
   default = {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -555,12 +555,23 @@ variable "cirrus_inputs" {
     workflows = optional(list(object({
       name                   = string
       non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      default_template_config = optional(object({
+        description = string
+        allow_retry = bool
+        state_sequence = list(object({
+          state_name = optional(string)
+          task_name  = string
+          task_type  = string
+        }))
+      }))
+      custom_template_config = optional(object({
+        filepath = string
+        variables = optional(map(object({
+          task_name = string
+          task_type = string
+          task_attr = string
+        })))
+      }))
     })))
   })
   default = {


### PR DESCRIPTION
Workflows that are nothing more than a sequential execution of Cirrus Tasks (states) can now be defined using the 'default_template_config' option without having to create a State Machine template. This should make Workflow creation significantly easier for common use cases. The custom template config is still available for complex Workflows.

## Related issue(s)

-

## Proposed Changes

1.

## Testing

This change was validated by the following observations:

1.

## Checklist

- [X] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
