### PR TITLE
Removed template_variables from cirrus workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Cirrus workflow's `template_variables` config is removed in favor of referencing cirrus task output attributes directly
+
 ### Fixed
 
 - Fixed the Cirrus `update-state` lambda permissions to allow:

--- a/inputs.tf
+++ b/inputs.tf
@@ -582,13 +582,7 @@ variable "cirrus_inputs" {
     })))
     workflows = optional(list(object({
       name                   = string
-      non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      state_machine_filepath = string
     })))
   })
   default = {

--- a/modules/cirrus/builtin_tasks.tf
+++ b/modules/cirrus/builtin_tasks.tf
@@ -154,20 +154,4 @@ locals {
     local.pre_batch_task_config,
     local.post_batch_task_config
   ]
-
-  # Map of pre-batch and post-batch builtin variables.
-  # Allows users to use "${PRE-BATCH}" and "${POST-BATCH}" in workflow templates
-  # without any additional config.
-  pre_batch_post_batch_task_template_variables = {
-    PRE-BATCH = {
-      task_name = local.pre_batch_task_config.name
-      task_type = "lambda"
-      task_attr = "function_arn"
-    }
-    POST-BATCH = {
-      task_name = local.post_batch_task_config.name
-      task_type = "lambda"
-      task_attr = "function_arn"
-    }
-  }
 }

--- a/modules/cirrus/inputs.tf
+++ b/modules/cirrus/inputs.tf
@@ -540,53 +540,24 @@ variable "cirrus_workflows" {
       - name: (required, string) Identifier for the Cirrus Workflow. Must be
         unique across all Cirrus Workflows. Valid characters are: [A-Za-z0-9-]
 
-      - non_cirrus_lambda_arns: (optional, list[string]) List of Lambda function
-        ARNs that'll be executed by the Workflow but are not managed by a Cirrus
-        task. This is necessary for granting the Workflow execution role invoke
-        permissions on these functions.
-
-      - template_filepath: (required, string) Path to an Amazon State Machine
-        definition template file. The path must be relative to the ROOT module
-        of the Terraform deployment. The template should use valid Amazon States
-        Language syntax; wherever a Cirrus Task resource ARN is needed, a
+      - state_machine_filepath: (required, string) Path to an Amazon State
+        Machine definition template file. The path must be relative to the ROOT
+        module of the Terraform deployment. The template should use valid Amazon
+        States Language syntax; wherever a Cirrus Task resource ARN is needed, a
         Terraform interpolation sequence (a "$\{...}" without the "\") may be
-        used instead. The variable name does not matter so long as there is a
-        corresponding entry in the "template_variables" argument.
+        used instead. The interpolation sequence should have the following form:
+          <TASK NAME>.<TASK TYPE>.<TASK ATTR>
+
+        Where:
+          <TASK NAME> : name of the task
+          <TASK TYPE> : one of [lambda, batch]
+          <TASK ATTR> : one of [function_arn, job_definition_arn, job_queue_arn]
+
         Example template snippet:
-
           "States": {
             "FirstState": {
               "Type": "Task",
-              "Resource": "$\{my-task-lambda}",  // REMOVE THE "\"
-              "Next": "SecondState",
-              ...
-            },
-
-        Cirrus may deploy and manage several builtin tasks. Resource ARNs for
-        these tasks may be referenced in a Workflow template using a predefined
-        variable name without having to supply a 'template_variable' entry.
-          - If Batch Tasks were created, the following variables may be used:
-            - PRE-BATCH: cirrus-geo pre-batch Lambda function ARN
-            - POST-BATCH: cirrus-geo post-batch Lambda function ARN
-
-      - template_variables: (optional, map[object]) A map of template variable
-        names to their corresponding Cirrus Task attributes. Assuming a Cirrus
-        Task named "my-task" with Lambda config was passed to the 'task' module,
-        the following workflow template variable config:
-
-          my-task-lambda = {
-            task_name = "my-task"
-            task_type = "lambda"
-            task_attr = "functon_arn"
-          }
-
-        when used with the example Workflow snippet above would result in the
-        following content after template interpolation:
-
-          "States": {
-            "FirstState": {
-              "Type": "Task",
-              "Resource": "arn:aws:lambda:us-west-2:123456789012:function:my-function",
+              "Resource": "$\{my-task.lambda.function_arn}",  // REMOVE THE "\"
               "Next": "SecondState",
               ...
             },
@@ -594,13 +565,7 @@ variable "cirrus_workflows" {
 
   type = list(object({
     name                   = string
-    non_cirrus_lambda_arns = optional(list(string))
-    template_filepath      = string
-    template_variables = optional(map(object({
-      task_name = string
-      task_type = string
-      task_attr = string
-    })))
+    state_machine_filepath = string
   }))
 
   default  = []

--- a/modules/cirrus/tasks_and_workflows.tf
+++ b/modules/cirrus/tasks_and_workflows.tf
@@ -15,15 +15,6 @@ locals {
     local.has_batch_task ? local.pre_batch_post_batch_task_configs : []
     # ... any future builtin tasks added here ...
   )
-
-  # Construct the full map of builtin task template variables:
-  # - If at least one Batch-style task was configured, the user may reference
-  #   pre-batch and post-batch function ARNs using their builtin variable names
-  # - ...
-  builtin_task_template_variables = merge(
-    local.has_batch_task ? local.pre_batch_post_batch_task_template_variables : {}
-    # ... any future builtin task variables added here ...
-  )
 }
 
 module "task_batch_compute" {
@@ -63,8 +54,7 @@ module "workflow" {
     workflow.name => workflow
   }
 
-  cirrus_prefix                   = local.cirrus_prefix
-  cirrus_tasks                    = module.task
-  workflow_config                 = each.value
-  builtin_task_template_variables = local.builtin_task_template_variables
+  cirrus_prefix   = local.cirrus_prefix
+  cirrus_tasks    = module.task
+  workflow_config = each.value
 }

--- a/modules/cirrus/workflow/inputs.tf
+++ b/modules/cirrus/workflow/inputs.tf
@@ -32,53 +32,24 @@ variable "workflow_config" {
       - name: (required, string) Identifier for the Cirrus Workflow. Must be
         unique across all Cirrus Workflows. Valid characters are: [A-Za-z0-9-]
 
-      - non_cirrus_lambda_arns: (optional, list[string]) List of Lambda function
-        ARNs that'll be executed by the Workflow but are not managed by a Cirrus
-        task. This is necessary for granting the Workflow execution role invoke
-        permissions on these functions.
-
-      - template_filepath: (required, string) Path to an Amazon State Machine
-        definition template file. The path must be relative to the ROOT module
-        of the Terraform deployment. The template should use valid Amazon States
-        Language syntax; wherever a Cirrus Task resource ARN is needed, a
+      - state_machine_filepath: (required, string) Path to an Amazon State
+        Machine definition template file. The path must be relative to the ROOT
+        module of the Terraform deployment. The template should use valid Amazon
+        States Language syntax; wherever a Cirrus Task resource ARN is needed, a
         Terraform interpolation sequence (a "$\{...}" without the "\") may be
-        used instead. The variable name does not matter so long as there is a
-        corresponding entry in the "template_variables" argument.
+        used instead. The interpolation sequence should have the following form:
+          <TASK NAME>.<TASK TYPE>.<TASK ATTR>
+
+        Where:
+          <TASK NAME> : name of the task
+          <TASK TYPE> : one of [lambda, batch]
+          <TASK ATTR> : one of [function_arn, job_definition_arn, job_queue_arn]
+
         Example template snippet:
-
           "States": {
             "FirstState": {
               "Type": "Task",
-              "Resource": "$\{my-task-lambda}",  // REMOVE THE "\"
-              "Next": "SecondState",
-              ...
-            },
-
-        Cirrus may deploy and manage several builtin tasks. Resource ARNs for
-        these tasks may be referenced in a Workflow template using a predefined
-        variable name without having to supply a 'template_variable' entry.
-          - If Batch Tasks were created, the following variables may be used:
-            - PRE-BATCH: cirrus-geo pre-batch Lambda function ARN
-            - POST-BATCH: cirrus-geo post-batch Lambda function ARN
-
-      - template_variables: (optional, map[object]) A map of template variable
-        names to their corresponding Cirrus Task attributes. Assuming a Cirrus
-        Task named "my-task" with Lambda config was passed to the 'task' module,
-        the following workflow template variable config:
-
-          my-task-lambda = {
-            task_name = "my-task"
-            task_type = "lambda"
-            task_attr = "function_arn"
-          }
-
-        when used with the example Workflow snippet above would result in the
-        following content after template interpolation:
-
-          "States": {
-            "FirstState": {
-              "Type": "Task",
-              "Resource": "arn:aws:lambda:us-west-2:123456789012:function:my-function",
+              "Resource": "$\{my-task.lambda.function_arn}",  // REMOVE THE "\"
               "Next": "SecondState",
               ...
             },
@@ -86,59 +57,9 @@ variable "workflow_config" {
 
   type = object({
     name                   = string
-    non_cirrus_lambda_arns = optional(list(string))
-    template_filepath      = string
-    template_variables = optional(map(object({
-      task_name = string
-      task_type = string
-      task_attr = string
-    })))
+    state_machine_filepath = string
   })
 
   # Value must be provided else this module serves no purpose
-  nullable = false
-
-  validation {
-    condition = (
-      var.workflow_config.template_variables != null
-      ? alltrue([
-        for _, tpl_variable in var.workflow_config.template_variables :
-        (
-          contains(
-            ["lambda", "batch"],
-            tpl_variable.task_type
-          )
-          && contains(
-            ["function_arn", "job_definition_arn", "job_queue_arn"],
-            tpl_variable.task_attr
-          )
-        )
-      ])
-      : true
-    )
-
-    error_message = <<-ERROR
-      Invalid template variable config. Each key must have a valid value:
-        - task_type => one of ["lambda", "batch"]
-        - task_attr => one of ["function_arn", "job_definition_arn", "job_queue_arn"]
-    ERROR
-  }
-}
-
-variable "builtin_task_template_variables" {
-  description = <<-DESCRIPTION
-    (optional, object) Key/value pairs of builtin task variables used during
-    workflow state machine templating. This should be set in the parent module
-    and not by user input.
-  DESCRIPTION
-
-  type = map(object({
-    task_name = string
-    task_type = string
-    task_attr = string
-  }))
-
-  # Value should always be a map (empty map is OK)
-  default  = {}
   nullable = false
 }

--- a/modules/cirrus/workflow/main.tf
+++ b/modules/cirrus/workflow/main.tf
@@ -6,49 +6,39 @@ locals {
   current_account = data.aws_caller_identity.current.account_id
   current_region  = data.aws_region.current.name
 
-  # Merge builtin template variable configs with the user-defined ones
-  merged_workflow_template_variables = merge(
-    var.builtin_task_template_variables,
-    var.workflow_config.template_variables
-  )
+  # Create the workflow's state machine JSON.
+  # Use the Cirrus task output mapping for interpolation.
+  # Decode the rendered JSON to strip newlines then encode to minify.
+  workflow_state_machine_json = jsonencode(jsondecode(templatefile(
+    "${path.root}/${var.workflow_config.state_machine_filepath}",
+    var.cirrus_tasks
+  )))
 
   # Gather any referenced Lambda Function ARNs.
   # These are needed for generating the workflow machine's IAM policies.
   # This includes both Cirrus- and non-Cirrus-managed Lambdas, if any.
-  workflow_tasks_lambda_functions = concat(
-    [
-      for _, v_cfg in local.merged_workflow_template_variables :
-      var.cirrus_tasks[v_cfg.task_name][v_cfg.task_type][v_cfg.task_attr]
-      if v_cfg.task_type == "lambda" && v_cfg.task_attr == "function_arn"
-    ],
-    try(coalesce(var.workflow_config.non_cirrus_lambda_arns, []), [])
-  )
+  workflow_tasks_lambda_functions = distinct(regexall(
+    "arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:[a-zA-Z0-9_-]+",
+    local.workflow_state_machine_json
+  ))
 
   # Gather any referenced Job Queue and Definition ARNs.
   # These are needed for generating the workflow machine's IAM policies.
-  workflow_tasks_batch_resources = [
-    for _, v_cfg in local.merged_workflow_template_variables :
-    var.cirrus_tasks[v_cfg.task_name][v_cfg.task_type][v_cfg.task_attr]
-    if v_cfg.task_type == "batch" && (
-      v_cfg.task_attr == "job_queue_arn" || v_cfg.task_attr == "job_definition_arn"
-    )
+  # Job definition ARNs add a wildcard suffix for the version number.
+  workflow_tasks_batch_job_resources = [
+    for job_def in distinct(regexall(
+      "arn:aws:batch:[a-z0-9-]+:[0-9]{12}:job-definition/[a-zA-Z0-9_-]+",
+      local.workflow_state_machine_json
+    )) : format("%s:*", job_def)
   ]
-
-  # Create the template variable mapping.
-  # Use each variable config as a lookup into the Cirrus Task outputs to obtain
-  # its intended string value that templatefile can use for interpolation.
-  workflow_template_variables_map = {
-    for v_name, v_cfg in local.merged_workflow_template_variables :
-    v_name => var.cirrus_tasks[v_cfg.task_name][v_cfg.task_type][v_cfg.task_attr]
-  }
-
-  # Create the workflow's state machine JSON.
-  # Use the template variable mapping above for interpolation.
-  # Decode the rendered JSON to strip newlines then encode to minify.
-  workflow_state_machine_json = jsonencode(jsondecode(templatefile(
-    "${path.root}/${var.workflow_config.template_filepath}",
-    local.workflow_template_variables_map
-  )))
+  workflow_tasks_batch_queue_resources = distinct(regexall(
+    "arn:aws:batch:[a-z0-9-]+:[0-9]{12}:job-queue/[a-zA-Z0-9_-]+",
+    local.workflow_state_machine_json
+  ))
+  workflow_tasks_batch_resources = concat(
+    local.workflow_tasks_batch_job_resources,
+    local.workflow_tasks_batch_queue_resources
+  )
 
   # Submit/Invoke permissions only necessary if Batch/Lambda resources are used
   create_batch_policy  = (length(local.workflow_tasks_batch_resources) != 0)
@@ -94,6 +84,7 @@ resource "aws_iam_role" "workflow_machine" {
 data "aws_iam_policy_document" "workflow_machine_events" {
   statement {
     # Allow the state machine to push state transition events
+    sid       = "AllowWorkflowToCreateStateTransitionEvents"
     effect    = "Allow"
     actions   = ["events:PutEvents"]
     resources = ["*"]
@@ -108,79 +99,80 @@ resource "aws_iam_role_policy" "workflow_machine_events" {
 # ==============================================================================
 
 
-# WORKFLOW STATE MACHINE IAM ROLE -- LAMBDA PERMISSIONS
+# WORKFLOW STATE MACHINE IAM ROLE -- BATCH AND LAMBDA PERMISSIONS
 # ------------------------------------------------------------------------------
-data "aws_iam_policy_document" "workflow_machine_task_lambda" {
-  count = local.create_lambda_policy ? 1 : 0
+data "aws_iam_policy_document" "workflow_machine_task_lambda_and_batch" {
 
-  statement {
-    # Allow the state machine to invoke all referenced task Lambdas
-    effect    = "Allow"
-    actions   = ["lambda:InvokeFunction"]
-    resources = local.workflow_tasks_lambda_functions
+  # Allow the state machine to invoke any referenced task Lambdas
+  dynamic "statement" {
+    for_each = local.create_lambda_policy ? [1] : []
+
+    content {
+      sid       = "AllowWorkflowToInvokeTaskLambdaFunctions"
+      effect    = "Allow"
+      actions   = ["lambda:InvokeFunction"]
+      resources = local.workflow_tasks_lambda_functions
+    }
+  }
+
+  # Batch only has partial support for resource-level permissions. See:
+  # https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html
+  #
+  # While "batch:TerminateJob" can be limited to specific Job ARNs, those ARNs
+  # are not known until Job submission. That action does support conditional
+  # policies via "aws:ResourceTag/Key", but there's no way to set Job tags via
+  # Terraform; the Job Definition's "propagate_tags" field only passes tags to
+  # the underlying ECS task and not the Batch Job itself. Thus, we cannot set
+  # a resource restriction for that action, either.
+  dynamic "statement" {
+    for_each = local.create_batch_policy ? [1] : []
+
+    content {
+      sid    = "AllowWorkflowToManageTaskBatchJobs"
+      effect = "Allow"
+      actions = [
+        "batch:DescribeJobs",
+        "batch:TerminateJob"
+      ]
+      resources = ["*"]
+    }
+  }
+
+  # Restrict Job submissions to the specified Job Definitions and Job Queues.
+  # Those resources are determined by the user's template variables, so this
+  # statement is nothing more than a simple guardrail against user error.
+  dynamic "statement" {
+    for_each = local.create_batch_policy ? [1] : []
+
+    content {
+      sid       = "AllowWorkflowToSubmitTaskBatchJobs"
+      effect    = "Allow"
+      actions   = ["batch:SubmitJob"]
+      resources = local.workflow_tasks_batch_resources
+    }
+  }
+
+  # Allow the state machine to monitor any Batch Jobs via the managed AWS rule
+  dynamic "statement" {
+    for_each = local.create_batch_policy ? [1] : []
+
+    content {
+      sid    = "AllowWorkflowToManageTaskBatchJobEvents"
+      effect = "Allow"
+      actions = [
+        "events:PutTargets",
+        "events:PutRule",
+        "events:DescribeRule"
+      ]
+      resources = ["arn:aws:events:${local.current_region}:${local.current_account}:rule/StepFunctionsGetEventsForBatchJobsRule"]
+    }
   }
 }
 
-resource "aws_iam_role_policy" "workflow_machine_task_lambda" {
-  count = local.create_lambda_policy ? 1 : 0
-
-  name_prefix = "${var.cirrus_prefix}-workflow-role-task-lambda-policy-"
+resource "aws_iam_role_policy" "workflow_machine_task_lambda_and_batch" {
+  name_prefix = "${var.cirrus_prefix}-workflow-role-task-policy-"
   role        = aws_iam_role.workflow_machine.name
-  policy      = data.aws_iam_policy_document.workflow_machine_task_lambda[0].json
-}
-# ==============================================================================
-
-
-# WORKFLOW STATE MACHINE IAM ROLE -- BATCH PERMISSIONS
-# ------------------------------------------------------------------------------
-data "aws_iam_policy_document" "workflow_machine_task_batch" {
-  count = local.create_batch_policy ? 1 : 0
-
-  statement {
-    # Batch only has partial support for resource-level permissions. See:
-    # https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html
-
-    # While "batch:TerminateJob" can be limited to specific Job ARNs, those ARNs
-    # are not known until Job submission. That action does support conditional
-    # policies via "aws:ResourceTag/Key", but there's no way to set Job tags via
-    # Terraform; the Job Definition's "propagate_tags" field only passes tags to
-    # the underlying ECS task and not the Batch Job itself. Thus, we cannot set
-    # a resource restriction for that action, either.
-    effect = "Allow"
-    actions = [
-      "batch:DescribeJobs",
-      "batch:TerminateJob"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    # Restrict Job submissions to the specified Job Definitions and Job Queues.
-    # Those resources are determined by the user's input template variables, so
-    # this statement is nothing more than a simple guardrail against user error.
-    effect    = "Allow"
-    actions   = ["batch:SubmitJob"]
-    resources = local.workflow_tasks_batch_resources
-  }
-
-  statement {
-    # Allow the state machine to monitor Batch Jobs via the managed AWS rule
-    effect = "Allow"
-    actions = [
-      "events:PutTargets",
-      "events:PutRule",
-      "events:DescribeRule"
-    ]
-    resources = ["arn:aws:events:${local.current_region}:${local.current_account}:rule/StepFunctionsGetEventsForBatchJobsRule"]
-  }
-}
-
-resource "aws_iam_role_policy" "workflow_machine_task_batch" {
-  count = local.create_batch_policy ? 1 : 0
-
-  name_prefix = "${var.cirrus_prefix}-workflow-role-task-batch-policy-"
-  role        = aws_iam_role.workflow_machine.name
-  policy      = data.aws_iam_policy_document.workflow_machine_task_batch[0].json
+  policy      = data.aws_iam_policy_document.workflow_machine_task_lambda_and_batch.json
 }
 # ==============================================================================
 

--- a/profiles/cirrus/inputs.tf
+++ b/profiles/cirrus/inputs.tf
@@ -254,13 +254,7 @@ variable "cirrus_inputs" {
     })))
     workflows = optional(list(object({
       name                   = string
-      non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      state_machine_filepath = string
     })))
   })
   default = {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -582,13 +582,7 @@ variable "cirrus_inputs" {
     })))
     workflows = optional(list(object({
       name                   = string
-      non_cirrus_lambda_arns = optional(list(string))
-      template_filepath      = string
-      template_variables = optional(map(object({
-        task_name = string
-        task_type = string
-        task_attr = string
-      })))
+      state_machine_filepath = string
     })))
   })
   default = {


### PR DESCRIPTION
This commit reduces the cirrus workflow module's complexity by relying on the user to simply provide Cirrus task output attribute lookups directly in their workflow state machine definition rather than using arbitrary variable names with associated entries under a workflow config 'template_variables' attribute.

The rendered JSON is now parsed via regexes to determine which resource ARNs the workflow IAM role needs permissions to execute. This also removes the need for the optional 'non_cirrus_lambda_arns' workflow config setting.

The workflow IAM role's lambda and batch policy documents were merged into one with conditional statements based on whether lambda or batch resources are used by the workflow's tasks.

## Related issue(s)

-

## Proposed Changes

1.

## Testing

This change was validated by the following observations:

1.

## Checklist

- [ ] I have deployed and validated this change
- [ ] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
