### PR TITLE
Move cirrus definitions to YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Inputs to the `cirrus` module's `task-batch-compute`, `task`, and `workflow` submodules are now defined via YAML files instead of HCL object lists
 - Cirrus workflow's `template_variables` config is removed in favor of referencing cirrus task output attributes directly
 
 ### Fixed

--- a/default.tfvars
+++ b/default.tfvars
@@ -193,9 +193,10 @@ cirrus_inputs = {
     timeout = 15
     memory  = 128
   }
-  task_batch_compute = []
-  tasks              = []
-  workflows          = []
+  task_batch_compute_definitions_dir = null
+  task_definitions_dir               = null
+  task_definitions_variables         = null
+  workflow_definitions_dir           = null
 }
 
 cirrus_dashboard_inputs = {

--- a/modules/cirrus/task-batch-compute/inputs.tf
+++ b/modules/cirrus/task-batch-compute/inputs.tf
@@ -14,6 +14,7 @@ variable "vpc_security_group_ids" {
 }
 
 variable "batch_compute_config" {
+  # NOTE: type changes here require changes in the typed-definitions module, too
   description = <<-DESCRIPTION
     (required, object) Defines a single set of Cirrus Task batch compute
     resources. This set may be used by zero..many batch Cirrus Tasks (see 'task'

--- a/modules/cirrus/task/inputs.tf
+++ b/modules/cirrus/task/inputs.tf
@@ -55,6 +55,7 @@ variable "cirrus_task_batch_compute" {
 }
 
 variable "task_config" {
+  # NOTE: type changes here require changes in the typed-definitions module, too
   description = <<-DESCRIPTION
     (required, object) Defines a single Cirrus Task. This Task may be used by
     zero..many Cirrus Workflows (see 'workflow' module). A Task may have Lambda

--- a/modules/cirrus/tasks_and_workflows.tf
+++ b/modules/cirrus/tasks_and_workflows.tf
@@ -1,26 +1,77 @@
 locals {
+  # These variables may be used in task definition templates for convenience.
+  builtin_task_definitions_variables = {
+    CIRRUS_DATA_BUCKET = var.cirrus_data_bucket
+  }
+
+  # Construct Cirrus task-batch-compute, task, and workflow definitions.
+  # These are loaded from YAML representations of each module's expected input
+  # config HCL objects. This approach avoids having excessively long inline
+  # config and promotes readability by enabling each item to be split into its
+  # own file without environment-specific redundancy.
+  #
+  # Task YAML definitions are templated prior to HCL conversion to allow setting
+  # any environment-specific values, including builtin variables defined above.
+  #
+  # Ternary defaults must be 'null' rather than an empty list since Terraform is
+  # unable to implicitly typecast the complex config objects into a single type,
+  # which would result in a type mismatch since tuple(n items) != list().
+  cirrus_task_batch_compute_definitions = (
+    var.cirrus_task_batch_compute_definitions_dir != null ? [
+      for tbc_yaml in fileset(path.root, "${var.cirrus_task_batch_compute_definitions_dir}/**/definition.yaml") :
+      yamldecode(file(tbc_yaml))
+    ] : null
+  )
+  cirrus_task_definitions = (
+    var.cirrus_task_definitions_dir != null ? [
+      for task_yaml in fileset(path.root, "${var.cirrus_task_definitions_dir}/**/definition.yaml") :
+      yamldecode(templatefile(task_yaml, merge(var.cirrus_task_definitions_variables, local.builtin_task_definitions_variables)))
+    ] : null
+  )
+  cirrus_workflow_definitions = (
+    var.cirrus_workflow_definitions_dir != null ? [
+      for workflow_yaml in fileset(path.root, "${var.cirrus_workflow_definitions_dir}/**/definition.yaml") :
+      yamldecode(file(workflow_yaml))
+    ] : null
+  )
+
   # Check if at least one task has a Batch configuration
-  has_batch_task = anytrue([
-    for task in coalesce(var.cirrus_tasks, []) :
-    task.batch != null
-  ])
+  has_batch_task = (
+    local.cirrus_task_definitions != null ? anytrue([
+      for task in local.cirrus_task_definitions :
+      try(task.batch, null) != null
+    ]) : false
+  )
 
   # Construct the full list of cirrus task configurations:
-  # - User-defined tasks are always created
+  # - User defined tasks are always created
   # - If at least one Batch-style task was configured, pre-batch and post-batch
   #   tasks will be injected into the list of desired Cirrus tasks
-  # - ...
-  cirrus_tasks = concat(
-    coalesce(var.cirrus_tasks, []),
-    local.has_batch_task ? local.pre_batch_post_batch_task_configs : []
-    # ... any future builtin tasks added here ...
+  merged_cirrus_task_definitions = (
+    local.cirrus_task_definitions != null ? concat(
+      local.cirrus_task_definitions,
+      local.has_batch_task ? local.pre_batch_post_batch_task_configs : []
+      # ... any future builtin tasks could be added here ...
+    ) : null
   )
+}
+
+module "typed_definitions" {
+  source = "./typed-definitions"
+
+  # The definitions constructed from YAML files above are tuples. We need a list
+  # of strictly-typed objects for variable-length module invocations below. This
+  # module call simply typecasts the input definitions and outputs the results.
+  # See that module's README for more information.
+  cirrus_task_batch_compute = local.cirrus_task_batch_compute_definitions
+  cirrus_tasks              = local.merged_cirrus_task_definitions
+  cirrus_workflows          = local.cirrus_workflow_definitions
 }
 
 module "task_batch_compute" {
   source = "./task-batch-compute"
   for_each = {
-    for compute in coalesce(var.cirrus_task_batch_compute, []) :
+    for compute in module.typed_definitions.cirrus_task_batch_compute :
     compute.name => compute
   }
 
@@ -33,7 +84,7 @@ module "task_batch_compute" {
 module "task" {
   source = "./task"
   for_each = {
-    for task in local.cirrus_tasks :
+    for task in module.typed_definitions.cirrus_tasks :
     task.name => task
   }
 
@@ -50,7 +101,7 @@ module "task" {
 module "workflow" {
   source = "./workflow"
   for_each = {
-    for workflow in coalesce(var.cirrus_workflows, []) :
+    for workflow in module.typed_definitions.cirrus_workflows :
     workflow.name => workflow
   }
 

--- a/modules/cirrus/typed-definitions/README.md
+++ b/modules/cirrus/typed-definitions/README.md
@@ -2,19 +2,18 @@
 
 This is a simple utility module created to facilitate storing Cirrus `task`,
 `task-batch-compute`, and `workflow` input configurations as individual YAML
-files instead.
+files rather than lists of HCL objects in each environment configuration.
 
 The object schema used by each of these modules is complex, and as such,
 Terraform is unable to automatically convert each tuple of disparate HCL objects
 derived from YAML into a list of typed objects. This leads to a number of
-type-related problems when the `cirrus` module has a variable number of the
-`task`, `task-batch-compute`, and `workflow` submodule invocations. These
-submodules operate on just one HCL configuration object at a time, so each tuple
-must be converted _after_ the `cirrus` module has read the YAML files into
-tuples but _before_ each submodule is called.
+type-related problems when the `cirrus` module has a variable number of `task`,
+`task-batch-compute`, and `workflow` submodule invocations.
 
-Thus, this module was created to sit between the two and perform explicit
-typecasting on each tuple in order to produce a list of typed objects. It does
-this by simply using `variable` blocks with strict object types that are
-immediately passed to `output` blocks. No additional logic or resource creation
-is necessary.
+Those submodules operate on just one HCL configuration object at a time, so each
+tuple must be converted _after_ the `cirrus` module has read the YAML files into
+tuples but _before_ each submodule is called. Thus, this module was created to
+sit between the two and perform explicit typecasting on each tuple in order to
+produce a list of typed objects. It does this by simply using `variable` blocks
+with strict object types that are immediately passed to `output` blocks. No
+additional logic or resource creation is necessary.

--- a/modules/cirrus/typed-definitions/README.md
+++ b/modules/cirrus/typed-definitions/README.md
@@ -1,0 +1,20 @@
+# Purpose
+
+This is a simple utility module created to facilitate storing Cirrus `task`,
+`task-batch-compute`, and `workflow` input configurations as individual YAML
+files instead.
+
+The object schema used by each of these modules is complex, and as such,
+Terraform is unable to automatically convert each tuple of disparate HCL objects
+derived from YAML into a list of typed objects. This leads to a number of
+type-related problems when the `cirrus` module has a variable number of the
+`task`, `task-batch-compute`, and `workflow` submodule invocations. These
+submodules operate on just one HCL configuration object at a time, so each tuple
+must be converted _after_ the `cirrus` module has read the YAML files into
+tuples but _before_ each submodule is called.
+
+Thus, this module was created to sit between the two and perform explicit
+typecasting on each tuple in order to produce a list of typed objects. It does
+this by simply using `variable` blocks with strict object types that are
+immediately passed to `output` blocks. No additional logic or resource creation
+is necessary.

--- a/modules/cirrus/typed-definitions/inputs.tf
+++ b/modules/cirrus/typed-definitions/inputs.tf
@@ -1,0 +1,264 @@
+variable "cirrus_task_batch_compute" {
+  description = <<-DESCRIPTION
+  (Optional) List of objects that conform to the task-batch-compute module's
+  "batch_compute_config" object schema. Used for explicitly typecasting the HCL
+  objects that were constructed from YAML definition files.
+
+  If null, an empty list is returned.
+  DESCRIPTION
+  type = list(object({
+    name = string
+
+    batch_compute_environment_existing = optional(object({
+      name       = string
+      is_fargate = bool
+    }))
+    batch_compute_environment = optional(object({
+      compute_resources = object({
+        max_vcpus           = number
+        type                = string
+        allocation_strategy = optional(string)
+        bid_percentage      = optional(number)
+        desired_vcpus       = optional(number)
+        ec2_configuration = optional(object({
+          image_id_override = optional(string)
+          image_type        = optional(string)
+        }))
+        ec2_key_pair       = optional(string)
+        instance_type      = optional(list(string))
+        min_vcpus          = optional(number)
+        placement_group    = optional(string)
+        security_group_ids = optional(list(string))
+        subnets            = optional(list(string))
+      })
+      state = optional(string)
+      type  = optional(string)
+      update_policy = optional(object({
+        job_execution_timeout_minutes = number
+        terminate_jobs_on_update      = bool
+      }))
+    }))
+    batch_job_queue_existing = optional(object({
+      name = string
+    }))
+    batch_job_queue = optional(object({
+      fair_share_policy = optional(object({
+        compute_reservation = optional(number)
+        share_decay_seconds = optional(number)
+        share_distributions = list(object({
+          share_identifier = string
+          weight_factor    = number
+        }))
+      }))
+      state = optional(string)
+    }))
+    ec2_launch_template_existing = optional(object({
+      name = string
+    }))
+    ec2_launch_template = optional(object({
+      user_data     = optional(string)
+      ebs_optimized = optional(bool)
+      block_device_mappings = optional(list(object({
+        device_name  = string
+        no_device    = optional(bool)
+        virtual_name = optional(string)
+        ebs = optional(object({
+          delete_on_termination = optional(bool)
+          encrypted             = optional(bool)
+          iops                  = optional(string)
+          kms_key_id            = optional(string)
+          snapshot_id           = optional(string)
+          throughput            = optional(number)
+          volume_size           = optional(number)
+          volume_type           = optional(string)
+        }))
+      })))
+    }))
+  }))
+
+  # Force default if null
+  nullable = false
+  default  = []
+
+  validation {
+    condition     = length(var.cirrus_task_batch_compute) == length(distinct(var.cirrus_task_batch_compute[*].name))
+    error_message = "Each cirrus task batch compute name must be unique to avoid resource clobbering"
+  }
+
+  validation {
+    condition = alltrue([
+      for name in var.cirrus_task_batch_compute[*].name :
+      length(regexall("^[A-Za-z0-9-]+$", name)) > 0 ? true : false
+    ])
+    error_message = "Each cirrus task batch compute name must only use alphanumeric characters and hyphens"
+  }
+}
+
+variable "cirrus_tasks" {
+  description = <<-DESCRIPTION
+  (Optional) List of objects that conform to the task module's "task_config"
+  object schema. Used for explicitly typecasting the HCL objects that were
+  constructed from YAML definition files.
+
+  If null, an empty list is returned.
+  DESCRIPTION
+  type = list(object({
+    name = string
+    common_role_statements = optional(list(object({
+      sid           = string
+      effect        = string
+      actions       = list(string)
+      resources     = list(string)
+      not_actions   = optional(list(string))
+      not_resources = optional(list(string))
+      condition = optional(object({
+        test     = string
+        variable = string
+        values   = list(string)
+      }))
+      principals = optional(object({
+        type        = string
+        identifiers = list(string)
+      }))
+      not_principals = optional(object({
+        type        = string
+        identifiers = list(string)
+      }))
+    })))
+    lambda = optional(object({
+      description   = optional(string)
+      ecr_image_uri = optional(string)
+      filename      = optional(string)
+      image_config = optional(object({
+        command           = optional(list(string))
+        entry_point       = optional(list(string))
+        working_directory = optional(string)
+      }))
+      s3_bucket       = optional(string)
+      s3_key          = optional(string)
+      handler         = optional(string)
+      runtime         = optional(string)
+      timeout_seconds = optional(number)
+      memory_mb       = optional(number)
+      publish         = optional(bool)
+      architectures   = optional(list(string))
+      env_vars        = optional(map(string))
+      vpc_enabled     = optional(bool)
+      role_statements = optional(list(object({
+        sid           = string
+        effect        = string
+        actions       = list(string)
+        resources     = list(string)
+        not_actions   = optional(list(string))
+        not_resources = optional(list(string))
+        condition = optional(object({
+          test     = string
+          variable = string
+          values   = list(string)
+        }))
+        principals = optional(object({
+          type        = string
+          identifiers = list(string)
+        }))
+        not_principals = optional(object({
+          type        = string
+          identifiers = list(string)
+        }))
+      })))
+      alarms = optional(list(object({
+        critical            = bool
+        statistic           = string
+        metric_name         = string
+        comparison_operator = string
+        threshold           = number
+        period              = optional(number, 60)
+        evaluation_periods  = optional(number, 5)
+      })))
+    }))
+    batch = optional(object({
+      task_batch_compute_name = string
+      container_properties    = string
+      retry_strategy = optional(object({
+        attempts = number
+        evaluate_on_exit = optional(list(object({
+          action           = string
+          on_exit_code     = optional(string)
+          on_reason        = optional(string)
+          on_status_reason = optional(string)
+        })))
+      }))
+      parameters = optional(map(string))
+      role_statements = optional(list(object({
+        sid           = string
+        effect        = string
+        actions       = list(string)
+        resources     = list(string)
+        not_actions   = optional(list(string))
+        not_resources = optional(list(string))
+        condition = optional(object({
+          test     = string
+          variable = string
+          values   = list(string)
+        }))
+        principals = optional(object({
+          type        = string
+          identifiers = list(string)
+        }))
+        not_principals = optional(object({
+          type        = string
+          identifiers = list(string)
+        }))
+      })))
+      scheduling_priority = optional(number)
+      timeout_seconds     = optional(number)
+    }))
+  }))
+
+  # Force default if null
+  nullable = false
+  default  = []
+
+  validation {
+    condition     = length(var.cirrus_tasks) == length(distinct(var.cirrus_tasks[*].name))
+    error_message = "Each cirrus task name must be unique to avoid resource clobbering"
+  }
+
+  validation {
+    condition = alltrue([
+      for name in var.cirrus_tasks[*].name :
+      length(regexall("^[A-Za-z0-9-]+$", name)) > 0 ? true : false
+    ])
+    error_message = "Each cirrus task name must only use alphanumeric characters and hyphens"
+  }
+}
+
+variable "cirrus_workflows" {
+  description = <<-DESCRIPTION
+  (Optional) List of objects that conform to the workflow module's
+  "workflow_config" object schema. Used for explicitly typecasting the HCL
+  objects that were constructed from YAML definition files.
+
+  If null, an empty list is returned.
+  DESCRIPTION
+  type = list(object({
+    name                   = string
+    state_machine_filepath = string
+  }))
+
+  # Force default if null
+  nullable = false
+  default  = []
+
+  validation {
+    condition     = length(var.cirrus_workflows) == length(distinct(var.cirrus_workflows[*].name))
+    error_message = "Each cirrus workflow name must be unique to avoid resource clobbering"
+  }
+
+  validation {
+    condition = alltrue([
+      for name in var.cirrus_workflows[*].name :
+      length(regexall("^[A-Za-z0-9-]+$", name)) > 0 ? true : false
+    ])
+    error_message = "Each cirrus workflow name must only use alphanumeric characters and hyphens"
+  }
+}

--- a/modules/cirrus/typed-definitions/outputs.tf
+++ b/modules/cirrus/typed-definitions/outputs.tf
@@ -1,0 +1,11 @@
+output "cirrus_task_batch_compute" {
+  value = var.cirrus_task_batch_compute
+}
+
+output "cirrus_tasks" {
+  value = var.cirrus_tasks
+}
+
+output "cirrus_workflows" {
+  value = var.cirrus_workflows
+}

--- a/modules/cirrus/typed-definitions/providers.tf
+++ b/modules/cirrus/typed-definitions/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6, < 1.8.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.22"
+    }
+  }
+}

--- a/modules/cirrus/workflow/inputs.tf
+++ b/modules/cirrus/workflow/inputs.tf
@@ -26,6 +26,7 @@ variable "cirrus_tasks" {
 }
 
 variable "workflow_config" {
+  # NOTE: type changes here require changes in the typed-definitions module, too
   description = <<-DESCRIPTION
     (required, object) Defines a single Cirrus Workflow.
     Contents:

--- a/profiles/cirrus/inputs.tf
+++ b/profiles/cirrus/inputs.tf
@@ -73,190 +73,10 @@ variable "cirrus_inputs" {
       timeout = number
       memory  = number
     })
-    task_batch_compute = optional(list(object({
-      name = string
-      batch_compute_environment_existing = optional(object({
-        name       = string
-        is_fargate = bool
-      }))
-      batch_compute_environment = optional(object({
-        compute_resources = object({
-          max_vcpus           = number
-          type                = string
-          allocation_strategy = optional(string)
-          bid_percentage      = optional(number)
-          desired_vcpus       = optional(number)
-          ec2_configuration = optional(object({
-            image_id_override = optional(string)
-            image_type        = optional(string)
-          }))
-          ec2_key_pair       = optional(string)
-          instance_type      = optional(list(string))
-          min_vcpus          = optional(number)
-          placement_group    = optional(string)
-          security_group_ids = optional(list(string))
-          subnets            = optional(list(string))
-        })
-        state = optional(string)
-        type  = optional(string)
-        update_policy = optional(object({
-          job_execution_timeout_minutes = number
-          terminate_jobs_on_update      = bool
-        }))
-      }))
-      batch_job_queue_existing = optional(object({
-        name = string
-      }))
-      batch_job_queue = optional(object({
-        fair_share_policy = optional(object({
-          compute_reservation = optional(number)
-          share_decay_seconds = optional(number)
-          share_distributions = list(object({
-            share_identifier = string
-            weight_factor    = number
-          }))
-        }))
-        state = optional(string)
-      }))
-      ec2_launch_template_existing = optional(object({
-        name = string
-      }))
-      ec2_launch_template = optional(object({
-        user_data     = optional(string)
-        ebs_optimized = optional(bool)
-        block_device_mappings = optional(list(object({
-          device_name  = string
-          no_device    = optional(bool)
-          virtual_name = optional(string)
-          ebs = optional(object({
-            delete_on_termination = optional(bool)
-            encrypted             = optional(bool)
-            iops                  = optional(string)
-            kms_key_id            = optional(string)
-            snapshot_id           = optional(string)
-            throughput            = optional(number)
-            volume_size           = optional(number)
-            volume_type           = optional(string)
-          }))
-        })))
-      }))
-    })))
-    tasks = optional(list(object({
-      name = string
-      common_role_statements = optional(list(object({
-        sid           = string
-        effect        = string
-        actions       = list(string)
-        resources     = list(string)
-        not_actions   = optional(list(string))
-        not_resources = optional(list(string))
-        condition = optional(object({
-          test     = string
-          variable = string
-          values   = list(string)
-        }))
-        principals = optional(object({
-          type        = string
-          identifiers = list(string)
-        }))
-        not_principals = optional(object({
-          type        = string
-          identifiers = list(string)
-        }))
-      })))
-      lambda = optional(object({
-        description   = optional(string)
-        ecr_image_uri = optional(string)
-        filename      = optional(string)
-        image_config = optional(object({
-          command           = optional(list(string))
-          entry_point       = optional(list(string))
-          working_directory = optional(string)
-        }))
-        s3_bucket            = optional(string)
-        s3_key               = optional(string)
-        handler              = optional(string)
-        runtime              = optional(string)
-        timeout_seconds      = optional(number)
-        memory_mb            = optional(number)
-        ephemeral_storage_mb = optional(number)
-        publish              = optional(bool)
-        architectures        = optional(list(string))
-        env_vars             = optional(map(string))
-        vpc_enabled          = optional(bool)
-        role_statements = optional(list(object({
-          sid           = string
-          effect        = string
-          actions       = list(string)
-          resources     = list(string)
-          not_actions   = optional(list(string))
-          not_resources = optional(list(string))
-          condition = optional(object({
-            test     = string
-            variable = string
-            values   = list(string)
-          }))
-          principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-          not_principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-        })))
-        alarms = optional(list(object({
-          critical            = bool
-          statistic           = string
-          metric_name         = string
-          comparison_operator = string
-          threshold           = number
-          period              = optional(number, 60)
-          evaluation_periods  = optional(number, 5)
-        })))
-      }))
-      batch = optional(object({
-        task_batch_compute_name = string
-        container_properties    = string
-        retry_strategy = optional(object({
-          attempts = number
-          evaluate_on_exit = optional(list(object({
-            action           = string
-            on_exit_code     = optional(string)
-            on_reason        = optional(string)
-            on_status_reason = optional(string)
-          })))
-        }))
-        parameters = optional(map(string))
-        role_statements = optional(list(object({
-          sid           = string
-          effect        = string
-          actions       = list(string)
-          resources     = list(string)
-          not_actions   = optional(list(string))
-          not_resources = optional(list(string))
-          condition = optional(object({
-            test     = string
-            variable = string
-            values   = list(string)
-          }))
-          principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-          not_principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-        })))
-        scheduling_priority = optional(number)
-        timeout_seconds     = optional(number)
-      }))
-    })))
-    workflows = optional(list(object({
-      name                   = string
-      state_machine_filepath = string
-    })))
+    task_batch_compute_definitions_dir = optional(string)
+    task_definitions_dir               = optional(string)
+    task_definitions_variables         = optional(map(map(string)))
+    workflow_definitions_dir           = optional(string)
   })
   default = {
     data_bucket    = "cirrus-data-bucket-name"
@@ -298,9 +118,10 @@ variable "cirrus_inputs" {
       timeout = 15
       memory  = 128
     }
-    task_batch_compute = []
-    tasks              = []
-    workflows          = []
+    task_batch_compute_definitions_dir = null
+    task_definitions_dir               = null
+    task_definitions_variables         = null
+    workflow_definitions_dir           = null
   }
 }
 

--- a/profiles/cirrus/main.tf
+++ b/profiles/cirrus/main.tf
@@ -29,7 +29,8 @@ module "cirrus" {
   warning_sns_topic_arn                                     = var.warning_sns_topic_arn
   critical_sns_topic_arn                                    = var.critical_sns_topic_arn
   deploy_alarms                                             = var.cirrus_inputs.deploy_alarms
-  cirrus_task_batch_compute                                 = var.cirrus_inputs.task_batch_compute
-  cirrus_tasks                                              = var.cirrus_inputs.tasks
-  cirrus_workflows                                          = var.cirrus_inputs.workflows
+  cirrus_task_batch_compute_definitions_dir                 = var.cirrus_inputs.task_batch_compute_definitions_dir
+  cirrus_task_definitions_dir                               = var.cirrus_inputs.task_definitions_dir
+  cirrus_task_definitions_variables                         = var.cirrus_inputs.task_definitions_variables
+  cirrus_workflow_definitions_dir                           = var.cirrus_inputs.workflow_definitions_dir
 }

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -401,190 +401,10 @@ variable "cirrus_inputs" {
       timeout = number
       memory  = number
     })
-    task_batch_compute = optional(list(object({
-      name = string
-      batch_compute_environment_existing = optional(object({
-        name       = string
-        is_fargate = bool
-      }))
-      batch_compute_environment = optional(object({
-        compute_resources = object({
-          max_vcpus           = number
-          type                = string
-          allocation_strategy = optional(string)
-          bid_percentage      = optional(number)
-          desired_vcpus       = optional(number)
-          ec2_configuration = optional(object({
-            image_id_override = optional(string)
-            image_type        = optional(string)
-          }))
-          ec2_key_pair       = optional(string)
-          instance_type      = optional(list(string))
-          min_vcpus          = optional(number)
-          placement_group    = optional(string)
-          security_group_ids = optional(list(string))
-          subnets            = optional(list(string))
-        })
-        state = optional(string)
-        type  = optional(string)
-        update_policy = optional(object({
-          job_execution_timeout_minutes = number
-          terminate_jobs_on_update      = bool
-        }))
-      }))
-      batch_job_queue_existing = optional(object({
-        name = string
-      }))
-      batch_job_queue = optional(object({
-        fair_share_policy = optional(object({
-          compute_reservation = optional(number)
-          share_decay_seconds = optional(number)
-          share_distributions = list(object({
-            share_identifier = string
-            weight_factor    = number
-          }))
-        }))
-        state = optional(string)
-      }))
-      ec2_launch_template_existing = optional(object({
-        name = string
-      }))
-      ec2_launch_template = optional(object({
-        user_data     = optional(string)
-        ebs_optimized = optional(bool)
-        block_device_mappings = optional(list(object({
-          device_name  = string
-          no_device    = optional(bool)
-          virtual_name = optional(string)
-          ebs = optional(object({
-            delete_on_termination = optional(bool)
-            encrypted             = optional(bool)
-            iops                  = optional(string)
-            kms_key_id            = optional(string)
-            snapshot_id           = optional(string)
-            throughput            = optional(number)
-            volume_size           = optional(number)
-            volume_type           = optional(string)
-          }))
-        })))
-      }))
-    })))
-    tasks = optional(list(object({
-      name = string
-      common_role_statements = optional(list(object({
-        sid           = string
-        effect        = string
-        actions       = list(string)
-        resources     = list(string)
-        not_actions   = optional(list(string))
-        not_resources = optional(list(string))
-        condition = optional(object({
-          test     = string
-          variable = string
-          values   = list(string)
-        }))
-        principals = optional(object({
-          type        = string
-          identifiers = list(string)
-        }))
-        not_principals = optional(object({
-          type        = string
-          identifiers = list(string)
-        }))
-      })))
-      lambda = optional(object({
-        description   = optional(string)
-        ecr_image_uri = optional(string)
-        filename      = optional(string)
-        image_config = optional(object({
-          command           = optional(list(string))
-          entry_point       = optional(list(string))
-          working_directory = optional(string)
-        }))
-        s3_bucket            = optional(string)
-        s3_key               = optional(string)
-        handler              = optional(string)
-        runtime              = optional(string)
-        timeout_seconds      = optional(number)
-        memory_mb            = optional(number)
-        ephemeral_storage_mb = optional(number)
-        publish              = optional(bool)
-        architectures        = optional(list(string))
-        env_vars             = optional(map(string))
-        vpc_enabled          = optional(bool)
-        role_statements = optional(list(object({
-          sid           = string
-          effect        = string
-          actions       = list(string)
-          resources     = list(string)
-          not_actions   = optional(list(string))
-          not_resources = optional(list(string))
-          condition = optional(object({
-            test     = string
-            variable = string
-            values   = list(string)
-          }))
-          principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-          not_principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-        })))
-        alarms = optional(list(object({
-          critical            = bool
-          statistic           = string
-          metric_name         = string
-          comparison_operator = string
-          threshold           = number
-          period              = optional(number, 60)
-          evaluation_periods  = optional(number, 5)
-        })))
-      }))
-      batch = optional(object({
-        task_batch_compute_name = string
-        container_properties    = string
-        retry_strategy = optional(object({
-          attempts = number
-          evaluate_on_exit = optional(list(object({
-            action           = string
-            on_exit_code     = optional(string)
-            on_reason        = optional(string)
-            on_status_reason = optional(string)
-          })))
-        }))
-        parameters = optional(map(string))
-        role_statements = optional(list(object({
-          sid           = string
-          effect        = string
-          actions       = list(string)
-          resources     = list(string)
-          not_actions   = optional(list(string))
-          not_resources = optional(list(string))
-          condition = optional(object({
-            test     = string
-            variable = string
-            values   = list(string)
-          }))
-          principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-          not_principals = optional(object({
-            type        = string
-            identifiers = list(string)
-          }))
-        })))
-        scheduling_priority = optional(number)
-        timeout_seconds     = optional(number)
-      }))
-    })))
-    workflows = optional(list(object({
-      name                   = string
-      state_machine_filepath = string
-    })))
+    task_batch_compute_definitions_dir = optional(string)
+    task_definitions_dir               = optional(string)
+    task_definitions_variables         = optional(map(map(string)))
+    workflow_definitions_dir           = optional(string)
   })
   default = {
     data_bucket    = "cirrus-data-bucket-name"
@@ -626,9 +446,10 @@ variable "cirrus_inputs" {
       timeout = 15
       memory  = 128
     }
-    task_batch_compute = []
-    tasks              = []
-    workflows          = []
+    task_batch_compute_definitions_dir = null
+    task_definitions_dir               = null
+    task_definitions_variables         = null
+    workflow_definitions_dir           = null
   }
 }
 


### PR DESCRIPTION
Inputs to the task-batch-compute, task, and workflow submodules are now configured via YAML definitions stored in individual directories and files rather than long lists of HCL objects. This prevents redundant cirrus configuration across deployment environments while still allowing for environment-specific values to be set via template variables in task definitions.

A new cirrus submodule, `typed-definitions`, was created to facilitate this change by addressing Terraform's difficulty with implicit typecasting of complex objects derived from YAML definitions. This module is used behind the scenes and should not be called by the user.

## Related issue(s)

- N/A

## Proposed Changes

1. The `cirrus` module (and all upstream modules) no longer take lists of `task`, `task-batch-compute`, and `workflow` config objects. Instead, it accepts the following:
    - `task_batch_compute_definitions_dir` - filepath to the directory containing subdirectories with `task-batch-compute` YAML definitions. Filepath is relative to the Terraform deployment's root directory.
    - `task_definitions_dir` - filepath to the directory containing subdirectories with `task` YAML definitions. Filepath is relative to the Terraform deployment's root directory.
    - `task_definitions_variables` - map of maps to strings. Used for templating `task` YAML definitions with any environment-specific values, such as data buckets. The outer map keys should be task names, the inner map keys a name that represents the placeholder's purpose (e.g., `{ copy-assets = { image_tag = "v3.0" }}`). See example below for more.
    - `workflow_definitions_dir` - filepath to the directory containing subdirectories with `workflow` YAML definitions. Filepath is relative to the Terraform deployment's root directory.
 2. At runtime, the `cirrus` module will glob each of the specified directories above for any `definition.yaml` files that are one level deep, e.g. `<definitions dir>/<namespaced dir>/definition.yaml`. Each set of globbed YAML files are decoded into a list of their HCL equivalent objects. `task` YAML definitions are templated prior to HCL conversion using the `task_definitions_variables` contents. `task-batch-compute` and `workflow` YAML definitions are not templated; contents are the same across all environments (though workflow state machine JSONs are different by necessity - this is handled by the `cirrus` module).
 3. Terraform struggles with implicitly typecasting lists of disparate HCL objects derived from YAML into a list of single-type objects, likely because some will omit optional attributes. This leads to a number of type-related issues during `cirrus`'s submodule executions. Thus, the `typed-definitions` submodule was added under `cirrus` to explicitly convert these tuples to their expected type (along with some additional input validation). The resulting list of objects are passed to the `task`, `task-batch-compute`, and `workflow` submodules. The user does not need to use this submodule directly; the `cirrus` module will use it automatically.
 4. The resulting `task`, `task-batch-compute`, and `workflow` resources are created just as before.

## Converting to YAML

1. Create the following the directory structure at the root of your repository:
```text
cirrus/
    task-batch-compute/
    tasks/
    workflows/
```

2. For each element in your `cirrus_inputs.task_batch_compute` list, perform the following steps:
    1. Create a new directory under `cirrus/task-batch-compute`. The directory name should match that object's `name` attribute.
    2. Create a file named `definition.yaml` under this new subdirectory. Convert the contents of that single HCL element into its YAML equivalent.
    3. (optional) Create a file named `README.md` with any information about this `task-batch-compute` item that you deem useful (purpose, etc.).

Updated layout: 
```text
cirrus/
    task-batch-compute/
        my-compute/
            definition.yaml
            README.md
        my-other-compute/
            definition.yaml
            README.md
        ...
    tasks/
    workflows/
```

Example source HCL:
```HCL
task_batch_compute = [
  {
    name = "my-compute"
    batch_compute_environment = {
      compute_resources = {
        type = "FARGATE_SPOT"
        max_vcpus = 4
      }
    }
  },
  ...
]
```

Example converted YAML:
```YAML
name: my-compute
batch_compute_environment:
  compute_resources:
    type: FARGATE_SPOT
    max_vcpus: 4
```

3. For each element in your `cirrus_inputs.tasks` list, perform the following steps:
    1. Create a new directory under `cirrus/tasks`. The directory name should match that object's `name` attribute.
    2. Create a file named `definition.yaml` under this new subdirectory. Convert the contents of that single HCL element into its YAML equivalent. If there are any values that might be specific to a given deployment environment, such as a source data bucket, you should template those now:
        - Replace the environment-specific value with a template sequence, e.g.: `${my-first-task.image_tag}`
        - In the `cirrus_inputs.task_definitions_variables` HCL variable, add an entry with a value specific to your target environment, e.g.: `{ my_first_task = { image_tag = "dev", ...} ...}`. This value will be templated into your task definition at runtime prior to HCL conversion.
        - Since the cirrus data bucket will always differ between environments, you may use the builtin template variable of `${CIRRUS_DATA_BUCKET}` in your task YAML definition **without** having to add an entry for it to `cirrus_inputs.task_definitions_variables`.
    3. (optional) Create a file named `README.md` with any information about this `task` item that you deem useful (purpose, source code repo link, etc.).

Updated layout: 
```text
cirrus/
    task-batch-compute/
        my-compute/
            definition.yaml
            README.md
        my-other-compute/
            definition.yaml
            README.md
        ...
    tasks/
        my-first-task/
            definition.yaml
            README.md
        my-second-task/
            definition.yaml
            README.md
        ...
    workflows/
```

Example source HCL for a `dev` environment:
```HCL
tasks = [
  {
    name = "my-first-task"
    common_role_statements = [
      {
        sid = "ReadSomeBucketThatsDifferentForEachEnvironment"
        effect = "Allow"
        actions = [
          "s3:ListBucket",
          "s3:GetObject",
          "s3:GetBucketLocation"
        ]
        resources = [
          "arn:aws:s3:::my-data-bucket",
          "arn:aws:s3:::my-data-bucket/*"
        ]
      },
      {
        sid = "WriteCirrusDataBucket"
        effect = "Allow"
        actions = ["s3:PutObject"]
        resources = ["arn:aws:s3:::cirrus-data-bucket/*"]
      }
    ]
    lambda = {
      description = "Cirrus task that does something"
      ecr_image_uri = "<full ECR image URI>:dev"
      vpc_enabled = true
      timeout_seconds = 900
      memory_mb = 128
      env_vars = {
        SOME_VARIABLE_YOUR_CODE_NEEDS = "some-value"
        SOME_VARIABLE_YOUR_CODE_NEEDS_THAT_CHANGES_BY_ENVIRONMENT = "DEV"
      }
    }
  },
  ...
]

```

Example converted YAML that would be used across all environments:
```YAML
name: my-first-task
common_role_statements:
  - sid: ReadSomeBucketThatsDifferentForEachEnvironment
    effect: Allow
    actions:
      - s3:ListBucket
      - s3:GetObject
      - s3:GetBucketLocation
    resources:
      - arn:aws:s3:::${my-first-task.ancillary_data_bucket}
      - arn:aws:s3:::${my-first-task.ancillary_data_bucket}/*
  - sid: WriteCirrusDataBucket
    effect: Allow
    actions:
      - s3:PutObject
    resources:
      - arn:aws:s3:::${CIRRUS_DATA_BUCKET}/*
lambda:
  description: Cirrus task that does something
  ecr_image_uri: <full ECR image URI>:${my-first-task.image_tag}
  vpc_enabled: true
  timeout_seconds: 900
  memory_mb: 128
  env_vars:
    SOME_VARIABLE_YOUR_CODE_NEEDS: some-value
    SOME_VARIABLE_YOUR_CODE_NEEDS_THAT_CHANGES_BY_ENVIRONMENT: ${my-first-task.env_variable}
```

Example `cirrus_inputs.task_definitions_variables` for the `dev` environment:
```HCL
task_definitions_variables = {
  my-first-task = {
    image_tag = "dev"
    ancillary_data_bucket = "my-data-bucket"
    env_variable = "DEV"
  }
}
```

5. For each element in your `cirrus_inputs.workflows` list, perform the following steps:
    1. Create a new directory under `cirrus/workflows`. The directory name should match that object's `name` attribute.
    2. Create a file named `definition.yaml` under this new subdirectory. Convert the contents of that single HCL element into its YAML equivalent.
        - Note that `template_variables` is no longer used. You'll update the the state machine JSON accordingly in the next step.
        - Note that `template_filepath` is now named `state_machine_filepath`.
    4. Create a file named `state-machine.json` under this new subdirectory and fill it with the contents of your state machine JSON. Make sure your `definition.yaml`'s `state_machine_filepath` points to this file (path is relative to the root of the repo). If you haven't already replaced your usage of `template_variables`, do so now:
        - Wherever you need to reference a task resource ARN, such as a lambda function, replace your existing `${arbitrary_variable_name}` with the explicit lookup value, e.g. `${<your task name>.<task type>.<task attribute>}`, such as `${my-first-task.lambda.function_arn}`. [See here](https://github.com/Element84/filmdrop-aws-tf-modules/blob/main/modules/cirrus/workflow/inputs.tf#L43) for the valid values.
        - Remove the `template_variables` config from your `definition.yaml` if you haven't already.
    6. (optional) Create a file named `README.md` with any information about this `workflow` item that you deem useful (purpose, task flow, arch diagram, etc.).

Updated layout: 
```text
cirrus/
    task-batch-compute/
        my-compute/
            definition.yaml
            README.md
        my-other-compute/
            definition.yaml
            README.md
        ...
    tasks/
        my-first-task/
            definition.yaml
            README.md
        my-second-task/
            definition.yaml
            README.md
        ...
    workflows/
        my-workflow/
            definition.yaml
            state-machine.json
            README.md
        ...
```

Example source HCL:
```HCL
workflows = [
  {
    name = "my-workflow"
    state_machine_filepath = "old-filepath.json"
  },
  ...
]
```

Example converted YAML:
```YAML
name: my-workflow
state_machine_filepath: "cirrus/workflows/my-workflow/state-machine.json"
```

## Testing

This change was validated by the following observations:

1. This feature was deployed to an existing FilmDrop environment and, after running through the conversion steps outlined above, the changes were successfully deployed. If everything was configured properly, the old `task-batch-compute`, `task`, and `workflow` resources should be the same as they were before (though the state machine contents may change slightly based on the whims of Terraform's JSON diffing).

## Checklist

- [X] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
