### PR TITLE
Fix occasional for_each error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed occasional planning-time issue with a `data.aws_subnet` block in the `cirrus` and `stac-server` modules
+
 ### Removed
 
 ## [2.32.0] - 2024-02-12

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -150,7 +150,7 @@ resource "aws_vpc_endpoint" "cirrus_api_gateway_private" {
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
-  subnet_ids          = [for subnet in data.aws_subnet.selected : subnet.id]
+  subnet_ids          = data.aws_subnets.selected.ids
   security_group_ids  = aws_security_group.cirrus_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -132,7 +132,7 @@ resource "aws_security_group" "cirrus_api_gateway_private_vpce" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "cirrus_api_gateway_private_vpce" {
-  for_each = local.is_private_endpoint ? data.aws_subnet.selected : {}
+  for_each = local.is_private_endpoint ? { for x in data.aws_subnet.selected : x.id => x } : {}
 
   security_group_id = aws_security_group.cirrus_api_gateway_private_vpce[0].id
   description       = "Allow TCP on 443 for subnet ${each.value.id}"
@@ -150,7 +150,7 @@ resource "aws_vpc_endpoint" "cirrus_api_gateway_private" {
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
-  subnet_ids          = data.aws_subnets.selected.ids
+  subnet_ids          = data.aws_subnet.selected[*].id
   security_group_ids  = aws_security_group.cirrus_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -132,7 +132,7 @@ resource "aws_security_group" "cirrus_api_gateway_private_vpce" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "cirrus_api_gateway_private_vpce" {
-  for_each = local.is_private_endpoint ? { for x in data.aws_subnet.selected : x.id => x } : {}
+  for_each = local.is_private_endpoint ? { for s in data.aws_subnet.selected : s.id => s } : {}
 
   security_group_id = aws_security_group.cirrus_api_gateway_private_vpce[0].id
   description       = "Allow TCP on 443 for subnet ${each.value.id}"

--- a/modules/cirrus/builtin-functions/data.tf
+++ b/modules/cirrus/builtin-functions/data.tf
@@ -4,15 +4,8 @@ data "aws_caller_identity" "current" {
 data "aws_region" "current" {
 }
 
-data "aws_subnets" "selected" {
-  filter {
-    name   = "subnet-id"
-    values = var.vpc_subnet_ids
-  }
-}
-
 data "aws_subnet" "selected" {
-  for_each = toset(data.aws_subnets.selected.ids)
+  count = length(var.vpc_subnet_ids)
 
-  id = each.value
+  id = var.vpc_subnet_ids[count.index]
 }

--- a/modules/cirrus/builtin-functions/data.tf
+++ b/modules/cirrus/builtin-functions/data.tf
@@ -4,8 +4,15 @@ data "aws_caller_identity" "current" {
 data "aws_region" "current" {
 }
 
+data "aws_subnets" "selected" {
+  filter {
+    name   = "subnet-id"
+    values = var.vpc_subnet_ids
+  }
+}
+
 data "aws_subnet" "selected" {
-  for_each = toset(var.vpc_subnet_ids)
+  for_each = toset(data.aws_subnets.selected.ids)
 
   id = each.value
 }

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -87,7 +87,7 @@ resource "aws_vpc_endpoint" "stac_server_api_gateway_private" {
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
-  subnet_ids          = [for subnet in data.aws_subnet.selected : subnet.id]
+  subnet_ids          = data.aws_subnets.selected.ids
   security_group_ids  = aws_security_group.stac_server_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -69,7 +69,7 @@ resource "aws_security_group" "stac_server_api_gateway_private_vpce" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "stac_server_api_gateway_private_vcpe" {
-  for_each = local.is_private_endpoint ? { for x in data.aws_subnet.selected : x.id => x } : {}
+  for_each = local.is_private_endpoint ? { for s in data.aws_subnet.selected : s.id => s } : {}
 
   security_group_id = aws_security_group.stac_server_api_gateway_private_vpce[0].id
   description       = "Allow TCP on 443 for subnet ${each.value.id}"

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -69,7 +69,7 @@ resource "aws_security_group" "stac_server_api_gateway_private_vpce" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "stac_server_api_gateway_private_vcpe" {
-  for_each = local.is_private_endpoint ? data.aws_subnet.selected : {}
+  for_each = local.is_private_endpoint ? { for x in data.aws_subnet.selected : x.id => x } : {}
 
   security_group_id = aws_security_group.stac_server_api_gateway_private_vpce[0].id
   description       = "Allow TCP on 443 for subnet ${each.value.id}"
@@ -87,7 +87,7 @@ resource "aws_vpc_endpoint" "stac_server_api_gateway_private" {
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
-  subnet_ids          = data.aws_subnets.selected.ids
+  subnet_ids          = data.aws_subnet.selected[*].id
   security_group_ids  = aws_security_group.stac_server_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false

--- a/modules/stac-server/data.tf
+++ b/modules/stac-server/data.tf
@@ -22,10 +22,17 @@ data "archive_file" "waiting_for_opensearch_lambda_zip" {
   ]
 }
 
-data "aws_subnet" "selected" {
-  for_each = toset(var.vpc_subnet_ids)
+data "aws_subnets" "selected" {
+  filter {
+    name   = "subnet-id"
+    values = var.vpc_subnet_ids
+  }
+}
 
-  id = each.key
+data "aws_subnet" "selected" {
+  for_each = toset(data.aws_subnets.selected.ids)
+
+  id = each.value
 }
 
 # this forces the user_init_lambda_zip to always be built

--- a/modules/stac-server/data.tf
+++ b/modules/stac-server/data.tf
@@ -22,17 +22,10 @@ data "archive_file" "waiting_for_opensearch_lambda_zip" {
   ]
 }
 
-data "aws_subnets" "selected" {
-  filter {
-    name   = "subnet-id"
-    values = var.vpc_subnet_ids
-  }
-}
-
 data "aws_subnet" "selected" {
-  for_each = toset(data.aws_subnets.selected.ids)
+  count = length(var.vpc_subnet_ids)
 
-  id = each.value
+  id = var.vpc_subnet_ids[count.index]
 }
 
 # this forces the user_init_lambda_zip to always be built


### PR DESCRIPTION
A `data.aws_subnet` block used in the `stac-server` and `cirrus` module iterates over a list of subnets IDs passed as a variable. This block was previously using the `for_each` directive for iterating over these values. Terraform seems to occasionally struggle with determining what these values will be - some deployments work, some deployments don't (with seemingly no relevant differences in configuration).

Example error:
```
│ Error: Invalid for_each argument
│ 
│   on modules/stac-server/data.tf line 26, in data "aws_subnet" "selected":
│   26:   for_each = toset(var.vpc_subnet_ids)
│     ├────────────────
│     │ var.vpc_subnet_ids is list of string with 3 elements
│ 
│ The "for_each" set includes values derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to use a map
│ value where the keys are defined statically in your configuration and where
│ only the values contain apply-time results.
│ 
│ Alternatively, you could use the -target planning option to first apply
│ only the resources that the for_each value depends on, and then apply a
│ second time to fully converge.
```

Since the map keys can't be set statically in configuration, I've switched that block's iterator to use `count` instead of `for_each` since the length of that list is known at plan and apply time. The dependent resources still use `for_each`, albeit now with a map construction using the resulting `data.aws_subnet` list.

## Related issue(s)

- N/A

## Proposed Changes

1. Change the `for_each` iterator to `count` to circumvent referencing values that may be unknown at planning time.

## Testing

This change was validated by the following observations:

1. Added to an existing FilmDrop deployment that was working prior to the change. It continues to work without any resource re-creation necessary (as only the data source iterator changed).
2. Added to an existing FilmDrop deployment that initially reported the error; that deployment can now plan and apply changes.

## Checklist

- [X] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
