### PR TITLE
Allow a custom resource prefix in the cirrus module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Direct invocations of the cirrus module can now specify a custom resource prefix
+
 ### Changed
+
+- Renamed all instances of `cirrus_prefix` to `resource_prefix` as a preliminary step for adopting the latter as an input variable across all modules
 
 ### Fixed
 

--- a/modules/cirrus/base.tf
+++ b/modules/cirrus/base.tf
@@ -6,7 +6,7 @@ moved {
 module "base" {
   source = "./base"
 
-  cirrus_prefix                                             = local.cirrus_prefix
+  resource_prefix                                           = var.resource_prefix
   cirrus_process_sqs_timeout                                = var.cirrus_process_sqs_timeout
   cirrus_process_sqs_max_receive_count                      = var.cirrus_process_sqs_max_receive_count
   cirrus_timestream_magnetic_store_retention_period_in_days = var.cirrus_timestream_magnetic_store_retention_period_in_days

--- a/modules/cirrus/base/db.tf
+++ b/modules/cirrus/base/db.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "cirrus_state_dynamodb_table" {
-  name         = "${var.cirrus_prefix}-state"
+  name         = "${var.resource_prefix}-state"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "collections_workflow"
   range_key    = "itemids"
@@ -40,12 +40,12 @@ resource "aws_dynamodb_table" "cirrus_state_dynamodb_table" {
 }
 
 resource "aws_timestreamwrite_database" "cirrus_state_event_timestreamwrite_database" {
-  database_name = "${var.cirrus_prefix}-state-events"
+  database_name = "${var.resource_prefix}-state-events"
 }
 
 resource "aws_timestreamwrite_table" "cirrus_state_event_timestreamwrite_table" {
   database_name = aws_timestreamwrite_database.cirrus_state_event_timestreamwrite_database.database_name
-  table_name    = "${var.cirrus_prefix}-state-events-table"
+  table_name    = "${var.resource_prefix}-state-events-table"
 
   retention_properties {
     magnetic_store_retention_period_in_days = var.cirrus_timestream_magnetic_store_retention_period_in_days
@@ -55,7 +55,7 @@ resource "aws_timestreamwrite_table" "cirrus_state_event_timestreamwrite_table" 
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_state_event_system_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-state DynamoDB System Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-state DynamoDB System Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "SystemErrors"
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_event_system_errors_warning
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix} Cirrus State DynamoDB System Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix} Cirrus State DynamoDB System Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -76,7 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_event_system_errors_warning
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_state_user_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-state DynamoDB User Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-state DynamoDB User Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "UserErrors"
@@ -85,7 +85,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_user_errors_warning_alarm" 
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix} Cirrus State DynamoDB User Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix} Cirrus State DynamoDB User Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_user_errors_warning_alarm" 
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_state_events_system_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-state-events Timestream Events System Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-state-events Timestream Events System Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "SystemErrors"
@@ -106,7 +106,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_events_system_errors_warnin
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix} Cirrus State Timestream Events System Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix} Cirrus State Timestream Events System Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_events_system_errors_warnin
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_state_events_user_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-state-events Timestream Events User Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-state-events Timestream Events User Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "UserErrors"
@@ -127,7 +127,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_state_events_user_errors_warning_
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix} Cirrus State Timestream Events User Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix} Cirrus State Timestream Events User Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []

--- a/modules/cirrus/base/iam.tf
+++ b/modules/cirrus/base/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cirrus_instance_role" {
-  name_prefix = "${var.cirrus_prefix}-instance-role-"
+  name_prefix = "${var.resource_prefix}-instance-role-"
 
   assume_role_policy = <<EOF
 {
@@ -24,6 +24,6 @@ resource "aws_iam_role_policy_attachment" "cirrus_instance_role_policy_attachmen
 }
 
 resource "aws_iam_instance_profile" "cirrus_instance_profile" {
-  name_prefix = "${var.cirrus_prefix}-instance-profile-"
+  name_prefix = "${var.resource_prefix}-instance-profile-"
   role        = aws_iam_role.cirrus_instance_role.name
 }

--- a/modules/cirrus/base/inputs.tf
+++ b/modules/cirrus/base/inputs.tf
@@ -1,6 +1,7 @@
-variable "cirrus_prefix" {
-  description = "Prefix for Cirrus-managed resources"
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource."
   type        = string
+  nullable    = false
 }
 
 variable "cirrus_process_sqs_timeout" {

--- a/modules/cirrus/base/s3.tf
+++ b/modules/cirrus/base/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "cirrus_data_bucket" {
   count = var.cirrus_data_bucket == "" ? 1 : 0
 
-  bucket_prefix = var.cirrus_data_bucket == "" ? "${var.cirrus_prefix}-data-" : var.cirrus_data_bucket
+  bucket_prefix = var.cirrus_data_bucket == "" ? "${var.resource_prefix}-data-" : var.cirrus_data_bucket
   force_destroy = true
 }
 
 resource "aws_s3_bucket" "cirrus_payload_bucket" {
   count = var.cirrus_payload_bucket == "" ? 1 : 0
 
-  bucket_prefix = var.cirrus_payload_bucket == "" ? "${var.cirrus_prefix}-payload-" : var.cirrus_payload_bucket
+  bucket_prefix = var.cirrus_payload_bucket == "" ? "${var.resource_prefix}-payload-" : var.cirrus_payload_bucket
   force_destroy = true
 }

--- a/modules/cirrus/base/sns.tf
+++ b/modules/cirrus/base/sns.tf
@@ -1,14 +1,14 @@
 resource "aws_sns_topic" "cirrus_publish_sns_topic" {
-  name = "${var.cirrus_prefix}-publish"
+  name = "${var.resource_prefix}-publish"
 }
 
 resource "aws_sns_topic" "cirrus_workflow_event_sns_topic" {
-  name = "${var.cirrus_prefix}-workflow-event"
+  name = "${var.resource_prefix}-workflow-event"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_publish_sns_topic_notifications_failed_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-publish SNS Topic Notifications Failed Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-publish SNS Topic Notifications Failed Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "NumberOfNotificationsFailed"
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_publish_sns_topic_notifications_f
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-publish SNS Topic Notifications Failed Warning Alarm"
+  alarm_description         = "${var.resource_prefix}-publish SNS Topic Notifications Failed Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_publish_sns_topic_notifications_f
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_workflow_event_sns_topic_notifications_failed_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-workflow-event SNS Topic Notifications Failed Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-workflow-event SNS Topic Notifications Failed Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "NumberOfNotificationsFailed"
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_workflow_event_sns_topic_notifica
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-workflow-event SNS Topic Notifications Failed Warning Alarm"
+  alarm_description         = "${var.resource_prefix}-workflow-event SNS Topic Notifications Failed Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []

--- a/modules/cirrus/base/sqs.tf
+++ b/modules/cirrus/base/sqs.tf
@@ -1,5 +1,5 @@
 resource "aws_sqs_queue" "cirrus_process_sqs_queue" {
-  name                       = "${var.cirrus_prefix}-process"
+  name                       = "${var.resource_prefix}-process"
   visibility_timeout_seconds = var.cirrus_process_sqs_timeout
 
   redrive_policy = jsonencode({
@@ -9,16 +9,16 @@ resource "aws_sqs_queue" "cirrus_process_sqs_queue" {
 }
 
 resource "aws_sqs_queue" "cirrus_process_dead_letter_sqs_queue" {
-  name = "${var.cirrus_prefix}-process-dead-letter"
+  name = "${var.resource_prefix}-process-dead-letter"
 }
 
 resource "aws_sqs_queue" "cirrus_update_state_dead_letter_sqs_queue" {
-  name = "${var.cirrus_prefix}-update-state-dead-letter"
+  name = "${var.resource_prefix}-update-state-dead-letter"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_dead_letter_sqs_queue_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-update-state-dead-letter SQS DLQ Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-update-state-dead-letter SQS DLQ Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
   metric_name               = "ApproximateNumberOfMessagesVisible"
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_dead_letter_sqs_queu
   statistic                 = "Sum"
   threshold                 = 1
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-update-state-dead-letter DLQ Warning Alarm"
+  alarm_description         = "${var.resource_prefix}-update-state-dead-letter DLQ Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -4,7 +4,7 @@ locals {
 
 
 resource "aws_iam_role" "cirrus_api_lambda_role" {
-  name_prefix = "${var.cirrus_prefix}-api-role-"
+  name_prefix = "${var.resource_prefix}-api-role-"
 
   assume_role_policy = <<EOF
 {
@@ -24,7 +24,7 @@ EOF
 }
 
 resource "aws_iam_policy" "cirrus_api_lambda_policy" {
-  name_prefix = "${var.cirrus_prefix}-api-policy-"
+  name_prefix = "${var.resource_prefix}-api-policy-"
 
   # TODO: the secret thing is probably not gonna work without some fixes in boto3utils...
   # We should probably reconsider if this is the right solution.
@@ -44,7 +44,7 @@ resource "aws_iam_policy" "cirrus_api_lambda_policy" {
     {
       "Action": "secretsmanager:GetSecretValue",
       "Resource": [
-        "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.cirrus_prefix}*"
+        "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.resource_prefix}*"
       ],
       "Effect": "Allow"
     },
@@ -95,7 +95,7 @@ resource "aws_iam_role_policy_attachment" "cirrus_api_lambda_role_policy_attachm
 
 resource "aws_lambda_function" "cirrus_api" {
   filename         = var.cirrus_lambda_zip_filepath
-  function_name    = "${var.cirrus_prefix}-api"
+  function_name    = "${var.resource_prefix}-api"
   description      = "Cirrus API Lambda"
   role             = aws_iam_role.cirrus_api_lambda_role.arn
   handler          = "api.lambda_handler"
@@ -125,7 +125,7 @@ resource "aws_lambda_function" "cirrus_api" {
 resource "aws_security_group" "cirrus_api_gateway_private_vpce" {
   count = local.is_private_endpoint ? 1 : 0
 
-  name_prefix = "${var.cirrus_prefix}-apigw-vcpe-sg-"
+  name_prefix = "${var.resource_prefix}-apigw-vcpe-sg-"
   description = "Allows TCP inbound on 443 from VPC private subnet CIDRs"
 
   vpc_id = var.vpc_id
@@ -161,7 +161,7 @@ resource "aws_vpc_endpoint" "cirrus_api_gateway_private" {
 }
 
 resource "aws_api_gateway_rest_api" "cirrus_api_gateway" {
-  name = "${var.cirrus_prefix}-api"
+  name = "${var.resource_prefix}-api"
 
   endpoint_configuration {
     types            = [var.cirrus_api_rest_type]
@@ -264,7 +264,7 @@ resource "aws_api_gateway_deployment" "cirrus_api_gateway" {
 }
 
 resource "aws_cloudwatch_log_group" "cirrus_api_gateway_logs_group" {
-  name = "/aws/apigateway/${var.cirrus_prefix}-api-${aws_api_gateway_deployment.cirrus_api_gateway.rest_api_id}/${aws_api_gateway_deployment.cirrus_api_gateway.stage_name}"
+  name = "/aws/apigateway/${var.resource_prefix}-api-${aws_api_gateway_deployment.cirrus_api_gateway.rest_api_id}/${aws_api_gateway_deployment.cirrus_api_gateway.stage_name}"
 }
 
 locals {
@@ -312,7 +312,7 @@ resource "aws_lambda_permission" "cirrus_api_gateway_lambda_permission_proxy_res
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-api Lambda Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-api Lambda Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 5
   metric_name               = "Errors"
@@ -321,7 +321,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_warning_alarm" 
   statistic                 = "Sum"
   threshold                 = 10
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-api Cirrus Update-State Lambda Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix}-api Cirrus Update-State Lambda Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -333,7 +333,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_warning_alarm" 
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_critical_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "CRITICAL: ${var.cirrus_prefix}-api Lambda Errors Critical Alarm"
+  alarm_name                = "CRITICAL: ${var.resource_prefix}-api Lambda Errors Critical Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 5
   metric_name               = "Errors"
@@ -342,7 +342,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_critical_alarm"
   statistic                 = "Sum"
   threshold                 = 100
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-api Cirrus Update-State Lambda Errors Critical Alarm"
+  alarm_description         = "${var.resource_prefix}-api Cirrus Update-State Lambda Errors Critical Alarm"
   alarm_actions             = [var.critical_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []

--- a/modules/cirrus/builtin-functions/inputs.tf
+++ b/modules/cirrus/builtin-functions/inputs.tf
@@ -1,6 +1,7 @@
-variable "cirrus_prefix" {
-  description = "Prefix for Cirrus-managed resources"
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource."
   type        = string
+  nullable    = false
 }
 
 variable "cirrus_log_level" {

--- a/modules/cirrus/builtin-functions/update-state.tf
+++ b/modules/cirrus/builtin-functions/update-state.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cirrus_update_state_lambda_role" {
-  name_prefix = "${var.cirrus_prefix}-process-role-"
+  name_prefix = "${var.resource_prefix}-process-role-"
 
   assume_role_policy = <<EOF
 {
@@ -19,7 +19,7 @@ EOF
 }
 
 resource "aws_iam_policy" "cirrus_update_state_lambda_policy" {
-  name_prefix = "${var.cirrus_prefix}-process-policy-"
+  name_prefix = "${var.resource_prefix}-process-policy-"
 
   policy = <<EOF
 {
@@ -59,7 +59,7 @@ resource "aws_iam_policy" "cirrus_update_state_lambda_policy" {
       "Action": [
         "states:GetExecutionHistory"
       ],
-      "Resource": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.cirrus_prefix}-*"
+      "Resource": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-*"
     },
     {
       "Effect": "Allow",
@@ -104,7 +104,7 @@ resource "aws_iam_role_policy_attachment" "cirrus_update_state_lambda_role_polic
 
 resource "aws_lambda_function" "cirrus_update_state" {
   filename         = var.cirrus_lambda_zip_filepath
-  function_name    = "${var.cirrus_prefix}-update-state"
+  function_name    = "${var.resource_prefix}-update-state"
   description      = "Cirrus Update-State Lambda"
   role             = aws_iam_role.cirrus_update_state_lambda_role.arn
   handler          = "update_state.lambda_handler"
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "cirrus_update_state" {
 }
 
 resource "aws_cloudwatch_event_rule" "cirrus_update_state_rule" {
-  name = "${var.cirrus_prefix}-update-state-sfn-events"
+  name = "${var.resource_prefix}-update-state-sfn-events"
 
   event_pattern = <<EOF
 {
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_event_rule" "cirrus_update_state_rule" {
   "detail": {
     "stateMachineArn": [
       {
-        "prefix": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.cirrus_prefix}-"
+        "prefix": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
       }
     ],
     "status": [
@@ -164,7 +164,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "cirrus_update_state_target" {
-  target_id = "${var.cirrus_prefix}-update-state-event-target"
+  target_id = "${var.resource_prefix}-update-state-event-target"
   arn       = aws_lambda_function.cirrus_update_state.arn
   rule      = aws_cloudwatch_event_rule.cirrus_update_state_rule.name
 
@@ -186,7 +186,7 @@ resource "aws_lambda_permission" "cirrus_update_state_event_bridge_lambda_permis
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_lambda_errors_warning_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "WARNING: ${var.cirrus_prefix}-update-state Lambda Errors Warning Alarm"
+  alarm_name                = "WARNING: ${var.resource_prefix}-update-state Lambda Errors Warning Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 5
   metric_name               = "Errors"
@@ -195,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_lambda_errors_warnin
   statistic                 = "Sum"
   threshold                 = 10
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-update-state Cirrus Update-State Lambda Errors Warning Alarm"
+  alarm_description         = "${var.resource_prefix}-update-state Cirrus Update-State Lambda Errors Warning Alarm"
   alarm_actions             = [var.warning_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []
@@ -207,7 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_lambda_errors_warnin
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_lambda_errors_critical_alarm" {
   count                     = var.deploy_alarms ? 1 : 0
-  alarm_name                = "CRITICAL: ${var.cirrus_prefix}-update-state Lambda Errors Critical Alarm"
+  alarm_name                = "CRITICAL: ${var.resource_prefix}-update-state Lambda Errors Critical Alarm"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 5
   metric_name               = "Errors"
@@ -216,7 +216,7 @@ resource "aws_cloudwatch_metric_alarm" "cirrus_update_state_lambda_errors_critic
   statistic                 = "Sum"
   threshold                 = 100
   treat_missing_data        = "notBreaching"
-  alarm_description         = "${var.cirrus_prefix}-update-state Cirrus Update-State Lambda Errors Critical Alarm"
+  alarm_description         = "${var.resource_prefix}-update-state Cirrus Update-State Lambda Errors Critical Alarm"
   alarm_actions             = [var.critical_sns_topic_arn]
   ok_actions                = [var.warning_sns_topic_arn]
   insufficient_data_actions = []

--- a/modules/cirrus/builtin_functions.tf
+++ b/modules/cirrus/builtin_functions.tf
@@ -9,7 +9,7 @@ module "builtin_functions" {
   vpc_id                                           = var.vpc_id
   vpc_subnet_ids                                   = var.vpc_subnet_ids
   vpc_security_group_ids                           = var.vpc_security_group_ids
-  cirrus_prefix                                    = local.cirrus_prefix
+  resource_prefix                                  = var.resource_prefix
   cirrus_log_level                                 = var.cirrus_log_level
   cirrus_data_bucket                               = module.base.cirrus_data_bucket
   cirrus_payload_bucket                            = module.base.cirrus_payload_bucket

--- a/modules/cirrus/builtin_tasks.tf
+++ b/modules/cirrus/builtin_tasks.tf
@@ -59,7 +59,7 @@ locals {
           sid       = "AllowCirrusSecretsManagerRead"
           effect    = "Allow"
           actions   = ["secretsmanager:GetSecretValue"]
-          resources = ["arn:aws:secretsmanager:${local.current_region}:${local.current_account}:secret:${local.cirrus_prefix}*"]
+          resources = ["arn:aws:secretsmanager:${local.current_region}:${local.current_account}:secret:${var.resource_prefix}*"]
         },
         {
           sid       = "AllowCirrusPayloadS3BucketWrite"
@@ -131,7 +131,7 @@ locals {
           sid       = "AllowCirrusSecretsManagerRead"
           effect    = "Allow"
           actions   = ["secretsmanager:GetSecretValue"]
-          resources = ["arn:aws:secretsmanager:${local.current_region}:${local.current_account}:secret:${local.cirrus_prefix}*"]
+          resources = ["arn:aws:secretsmanager:${local.current_region}:${local.current_account}:secret:${var.resource_prefix}*"]
         },
         {
           sid       = "AllowCirrusPayloadS3BucketWrite"

--- a/modules/cirrus/data.tf
+++ b/modules/cirrus/data.tf
@@ -6,9 +6,6 @@ locals {
   current_account = data.aws_caller_identity.current.account_id
   current_region  = data.aws_region.current.name
 
-  # All Cirrus-managed resources will be prefixed with this identifier
-  cirrus_prefix = lower(substr(replace("fd-${var.project_name}-${var.environment}-cirrus", "_", "-"), 0, 63))
-
   # Use a custom Cirrus Lambda Dist ZIP or accept the module's builtin version
   cirrus_lambda_zip_filepath = (
     var.cirrus_lambda_zip_filepath != null

--- a/modules/cirrus/inputs.tf
+++ b/modules/cirrus/inputs.tf
@@ -1,19 +1,32 @@
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource."
+  type        = string
+  nullable    = false
+
+  # We limit the prefix length to 22 characters as that's just under the
+  # maximum possible length before we run into issues with 'name_prefix' limits
+  # on certain resources like IAM roles.
+  # We limit the character set to lowered alphanumerics and hyphens for
+  # consistency across FilmDrop modules. A leading hyphen is not allowed as that
+  # is generally not a valid AWS resource name. A trailing hyphen is not allowed
+  # as this module will add one where needed.
+  validation {
+    condition     = can(regex("^[0-9a-z][0-9a-z-]{0,20}[0-9a-z]$", var.resource_prefix))
+    error_message = <<-ERROR
+    The resource prefix must be 2-22 characters from [a-z0-9-] without a leading
+    or trailing hyphen.
+    ERROR
+  }
+}
+
 variable "environment" {
   description = "Project environment"
   type        = string
-  validation {
-    condition     = length(var.environment) <= 7
-    error_message = "The environment value must be 7 or fewer characters."
-  }
 }
 
 variable "project_name" {
   description = "Project Name"
   type        = string
-  validation {
-    condition     = length(var.project_name) <= 8
-    error_message = "The project_name value must be a 8 or fewer characters."
-  }
 }
 
 variable "cirrus_lambda_zip_filepath" {

--- a/modules/cirrus/param_store.tf
+++ b/modules/cirrus/param_store.tf
@@ -58,11 +58,11 @@ resource "aws_ssm_parameter" "state_db" {
 resource "aws_ssm_parameter" "base_workflow_arn" {
   name  = "${local.parameter_prefix}CIRRUS_BASE_WORKFLOW_ARN"
   type  = "String"
-  value = "arn:aws:states:${local.current_region}:${local.current_account}:stateMachine:${local.cirrus_prefix}-"
+  value = "arn:aws:states:${local.current_region}:${local.current_account}:stateMachine:${var.resource_prefix}-"
 }
 
 resource "aws_ssm_parameter" "cirrus_prefix" {
   name  = "${local.parameter_prefix}CIRRUS_PREFIX"
   type  = "String"
-  value = "${local.cirrus_prefix}-"
+  value = "${var.resource_prefix}-"
 }

--- a/modules/cirrus/task-batch-compute/inputs.tf
+++ b/modules/cirrus/task-batch-compute/inputs.tf
@@ -1,6 +1,7 @@
-variable "cirrus_prefix" {
-  description = "Prefix for Cirrus-managed resources"
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource."
   type        = string
+  nullable    = false
 }
 
 variable "vpc_subnet_ids" {

--- a/modules/cirrus/task-batch-compute/main.tf
+++ b/modules/cirrus/task-batch-compute/main.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "task_ec2_assume_role" {
 resource "aws_iam_role" "task_ec2" {
   count = local.create_instance_profile ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-compute-role-"
+  name_prefix        = "${var.resource_prefix}-compute-role-"
   description        = "EC2 instance role for Cirrus Task Compute '${var.batch_compute_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.task_ec2_assume_role[0].json
 }
@@ -134,7 +134,7 @@ resource "aws_iam_role_policy_attachment" "aws_managed_ecs_for_ec2" {
 resource "aws_iam_instance_profile" "task_ec2" {
   count = local.create_instance_profile ? 1 : 0
 
-  name_prefix = "${var.cirrus_prefix}-compute-role-"
+  name_prefix = "${var.resource_prefix}-compute-role-"
   role        = aws_iam_role.task_ec2[0].name
 }
 # ==============================================================================
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "task_ecs_assume_role" {
 resource "aws_iam_role" "task_ecs" {
   count = local.create_ecs_execution_role ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-compute-role-"
+  name_prefix        = "${var.resource_prefix}-compute-role-"
   assume_role_policy = data.aws_iam_policy_document.task_ecs_assume_role[0].json
 }
 
@@ -225,7 +225,7 @@ data "aws_iam_policy_document" "task_spot_fleet_assume_role" {
 resource "aws_iam_role" "task_spot_fleet" {
   count = local.create_spot_fleet_role ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-compute-role-"
+  name_prefix        = "${var.resource_prefix}-compute-role-"
   description        = "EC2 Spot Fleet role for Cirrus Task Compute '${var.batch_compute_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.task_spot_fleet_assume_role[0].json
 }
@@ -279,7 +279,7 @@ data "aws_iam_policy_document" "task_batch_assume_role" {
 resource "aws_iam_role" "task_batch" {
   count = local.create_compute_environment ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-compute-role-"
+  name_prefix        = "${var.resource_prefix}-compute-role-"
   description        = "Batch service role for Cirrus Task Compute '${var.batch_compute_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.task_batch_assume_role[0].json
 }
@@ -322,7 +322,7 @@ data "aws_launch_template" "task_batch" {
 resource "aws_launch_template" "task_batch" {
   count = local.create_launch_template ? 1 : 0
 
-  name        = "${var.cirrus_prefix}-compute-${var.batch_compute_config.name}"
+  name        = "${var.resource_prefix}-compute-${var.batch_compute_config.name}"
   description = "EC2 Launch Template for Cirrus Task Batch Compute item '${var.batch_compute_config.name}'"
 
   # Always update default to be the latest one managed by Terraform.
@@ -381,7 +381,7 @@ data "aws_batch_compute_environment" "task_batch" {
 resource "aws_batch_compute_environment" "task_batch" {
   count = local.create_compute_environment ? 1 : 0
 
-  compute_environment_name_prefix = "${var.cirrus_prefix}-task-compute-${var.batch_compute_config.name}-"
+  compute_environment_name_prefix = "${var.resource_prefix}-task-compute-${var.batch_compute_config.name}-"
   service_role                    = aws_iam_role.task_batch[0].arn
   state                           = coalesce(var.batch_compute_config.batch_compute_environment.state, "ENABLED")
   type                            = coalesce(var.batch_compute_config.batch_compute_environment.type, "MANAGED")
@@ -472,7 +472,7 @@ data "aws_batch_job_queue" "task_batch" {
 resource "aws_batch_scheduling_policy" "task_batch" {
   count = local.create_fair_share_policy ? 1 : 0
 
-  name = "${var.cirrus_prefix}-task-compute-${var.batch_compute_config.name}"
+  name = "${var.resource_prefix}-task-compute-${var.batch_compute_config.name}"
 
   fair_share_policy {
     compute_reservation = var.batch_compute_config.batch_job_queue.fair_share_policy.compute_reservation
@@ -494,7 +494,7 @@ resource "aws_batch_scheduling_policy" "task_batch" {
 resource "aws_batch_job_queue" "task_batch" {
   count = local.create_job_queue ? 1 : 0
 
-  name     = "${var.cirrus_prefix}-task-compute-${var.batch_compute_config.name}"
+  name     = "${var.resource_prefix}-task-compute-${var.batch_compute_config.name}"
   state    = try(coalesce(var.batch_compute_config.batch_job_queue.state, "ENABLED"), "ENABLED")
   priority = 1
 

--- a/modules/cirrus/task/batch.tf
+++ b/modules/cirrus/task/batch.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "task_batch_assume_role" {
 resource "aws_iam_role" "task_batch" {
   count = local.create_batch_job ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-task-role-"
+  name_prefix        = "${var.resource_prefix}-task-role-"
   description        = "Batch Job / ECS Task role for Cirrus Task '${var.task_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.task_batch_assume_role[0].json
 }
@@ -101,7 +101,7 @@ data "aws_iam_policy_document" "task_batch_role_payload_bucket_access" {
 resource "aws_iam_role_policy" "task_batch_role_payload_bucket_access" {
   count = local.create_batch_job ? 1 : 0
 
-  name_prefix = "${var.cirrus_prefix}-task-role-payload-policy-"
+  name_prefix = "${var.resource_prefix}-task-role-payload-policy-"
   role        = aws_iam_role.task_batch[0].name
   policy      = data.aws_iam_policy_document.task_batch_role_payload_bucket_access[0].json
 }
@@ -183,7 +183,7 @@ data "aws_iam_policy_document" "task_batch_role_additional" {
 resource "aws_iam_role_policy" "task_batch_role_additional" {
   count = local.create_additional_batch_policy ? 1 : 0
 
-  name_prefix = "${var.cirrus_prefix}-task-role-additional-policy-"
+  name_prefix = "${var.resource_prefix}-task-role-additional-policy-"
   role        = aws_iam_role.task_batch[0].name
   policy      = data.aws_iam_policy_document.task_batch_role_additional[0].json
 }
@@ -195,7 +195,7 @@ resource "aws_iam_role_policy" "task_batch_role_additional" {
 resource "aws_batch_job_definition" "task" {
   count = local.create_batch_job ? 1 : 0
 
-  name = "${var.cirrus_prefix}-${var.task_config.name}"
+  name = "${var.resource_prefix}-${var.task_config.name}"
 
   # Create the container properties JSON.
   # This decodes the user's input JSON string, merges the resulting HCL object

--- a/modules/cirrus/task/inputs.tf
+++ b/modules/cirrus/task/inputs.tf
@@ -1,6 +1,7 @@
-variable "cirrus_prefix" {
-  description = "Prefix for Cirrus-managed resources"
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource."
   type        = string
+  nullable    = false
 }
 
 variable "cirrus_payload_bucket" {

--- a/modules/cirrus/task/lambda.tf
+++ b/modules/cirrus/task/lambda.tf
@@ -21,7 +21,7 @@ locals {
   # Create the Lambda function name.
   # This is needed by the Lambda execution role prior to function creation, so a
   # resource reference cannot be used.
-  task_lambda_function_name = "${var.cirrus_prefix}-${var.task_config.name}"
+  task_lambda_function_name = "${var.resource_prefix}-${var.task_config.name}"
 
   # Lambdas running within the VPC will require additional permissions
   deploy_lambda_in_vpc = (
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "task_lambda_assume_role" {
 resource "aws_iam_role" "task_lambda" {
   count = local.create_lambda ? 1 : 0
 
-  name_prefix        = "${var.cirrus_prefix}-task-role-"
+  name_prefix        = "${var.resource_prefix}-task-role-"
   description        = "Lambda execution role for Cirrus Task '${var.task_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.task_lambda_assume_role[0].json
 }
@@ -171,7 +171,7 @@ data "aws_iam_policy_document" "task_lambda_role_additional" {
 resource "aws_iam_role_policy" "task_lambda_role_additional" {
   count = local.create_additional_lambda_policy ? 1 : 0
 
-  name_prefix = "${var.cirrus_prefix}-task-role-additional-policy-"
+  name_prefix = "${var.resource_prefix}-task-role-additional-policy-"
   role        = aws_iam_role.task_lambda[0].name
   policy      = data.aws_iam_policy_document.task_lambda_role_additional[0].json
 }
@@ -274,7 +274,7 @@ resource "aws_cloudwatch_metric_alarm" "task_lambda" {
 
   alarm_name = format(
     "%s-%s-%s-%s-alarm",
-    "${var.cirrus_prefix}-${var.task_config.name}-task-lambda",
+    "${var.resource_prefix}-${var.task_config.name}-task-lambda",
     lower(each.value.metric_name),
     lower(each.value.statistic),
     each.value.critical ? "critical" : "warning"
@@ -282,7 +282,7 @@ resource "aws_cloudwatch_metric_alarm" "task_lambda" {
 
   alarm_description = format(
     "%s %s %s %s Alarm",
-    "${var.cirrus_prefix}-${var.task_config.name} Task Lambda",
+    "${var.resource_prefix}-${var.task_config.name} Task Lambda",
     "${each.value.metric_name} ${each.value.statistic}",
     "${each.value.comparison_operator} ${each.value.threshold}",
     each.value.critical ? "Critical" : "Warning"

--- a/modules/cirrus/tasks_and_workflows.tf
+++ b/modules/cirrus/tasks_and_workflows.tf
@@ -75,7 +75,7 @@ module "task_batch_compute" {
     compute.name => compute
   }
 
-  cirrus_prefix          = local.cirrus_prefix
+  resource_prefix        = var.resource_prefix
   vpc_subnet_ids         = var.vpc_subnet_ids
   vpc_security_group_ids = var.vpc_security_group_ids
   batch_compute_config   = each.value
@@ -88,7 +88,7 @@ module "task" {
     task.name => task
   }
 
-  cirrus_prefix             = local.cirrus_prefix
+  resource_prefix           = var.resource_prefix
   cirrus_payload_bucket     = var.cirrus_payload_bucket
   vpc_subnet_ids            = var.vpc_subnet_ids
   vpc_security_group_ids    = var.vpc_security_group_ids
@@ -105,7 +105,7 @@ module "workflow" {
     workflow.name => workflow
   }
 
-  cirrus_prefix   = local.cirrus_prefix
+  resource_prefix = var.resource_prefix
   cirrus_tasks    = module.task
   workflow_config = each.value
 }

--- a/modules/cirrus/workflow/inputs.tf
+++ b/modules/cirrus/workflow/inputs.tf
@@ -1,6 +1,7 @@
-variable "cirrus_prefix" {
-  description = "Prefix for Cirrus-managed resources"
+variable "resource_prefix" {
+  description = "String prefix to be used in every named resource"
   type        = string
+  nullable    = false
 }
 
 variable "cirrus_tasks" {

--- a/modules/cirrus/workflow/main.tf
+++ b/modules/cirrus/workflow/main.tf
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "workflow_machine_assume_role" {
 }
 
 resource "aws_iam_role" "workflow_machine" {
-  name_prefix        = "${var.cirrus_prefix}-workflow-role-"
+  name_prefix        = "${var.resource_prefix}-workflow-role-"
   description        = "State Machine execution role for Cirrus Workflow '${var.workflow_config.name}'"
   assume_role_policy = data.aws_iam_policy_document.workflow_machine_assume_role.json
 }
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "workflow_machine_events" {
 }
 
 resource "aws_iam_role_policy" "workflow_machine_events" {
-  name_prefix = "${var.cirrus_prefix}-workflow-role-event-creation-"
+  name_prefix = "${var.resource_prefix}-workflow-role-event-creation-"
   role        = aws_iam_role.workflow_machine.name
   policy      = data.aws_iam_policy_document.workflow_machine_events.json
 }
@@ -170,7 +170,7 @@ data "aws_iam_policy_document" "workflow_machine_task_lambda_and_batch" {
 }
 
 resource "aws_iam_role_policy" "workflow_machine_task_lambda_and_batch" {
-  name_prefix = "${var.cirrus_prefix}-workflow-role-task-policy-"
+  name_prefix = "${var.resource_prefix}-workflow-role-task-policy-"
   role        = aws_iam_role.workflow_machine.name
   policy      = data.aws_iam_policy_document.workflow_machine_task_lambda_and_batch.json
 }
@@ -180,7 +180,7 @@ resource "aws_iam_role_policy" "workflow_machine_task_lambda_and_batch" {
 # WORKFLOW STATE MACHINE
 # ------------------------------------------------------------------------------
 resource "aws_sfn_state_machine" "workflow" {
-  name       = "${var.cirrus_prefix}-${var.workflow_config.name}"
+  name       = "${var.resource_prefix}-${var.workflow_config.name}"
   definition = local.workflow_state_machine_json
   publish    = true
   role_arn   = aws_iam_role.workflow_machine.arn

--- a/profiles/cirrus/main.tf
+++ b/profiles/cirrus/main.tf
@@ -1,6 +1,9 @@
 module "cirrus" {
   source = "../../modules/cirrus"
 
+  # Namespace all cirrus resources via prefix
+  resource_prefix = lower(replace("fd-${var.project_name}-${var.environment}-cirrus", "_", "-"))
+
   project_name                                              = var.project_name
   environment                                               = var.environment
   vpc_id                                                    = var.vpc_id


### PR DESCRIPTION
This change moves the semi-hardcoded cirrus resource prefix logic out of the cirrus module's `data.tf` and into a module-level input variable instead.

The primary reason for this change is to promote this module's independence as something that can be deployed on its own and not just through the full FilmDrop deployment. The resource prefix generation logic had previously forced `fd-` as the leading part of the prefix, which wasn't applicable for standalone cirrus deployments.

New and existing cirrus resources that are deployed as part of a full FilmDrop deployment will continue to have the same prefix as before as that variable gets interpolated in the cirrus profile (and is not exposed as a customizable input variable).

I've changed all instances of `var.cirrus_prefix` or `local.cirrus_prefix` to `var.resource_prefix` because we may want to consider adopting this approach for all FilmDrop modules; having a common `resource_prefix` input variable across _all_ modules would allow us to centralize the prefix generation logic within the core profile. I did not make those sweeping changes as part of this PR is it was out of scope.

## Related issue(s)

- N/A

## Proposed Changes

1. Replace `cirrus_prefix` with `resource_prefix` and expose it as a module-level input variable

## Testing

This change was validated by the following observations:

1. Deploying this change to an existing FIlmDrop project that was using cirrus led to no changes; the `resource_prefix` is being set in the cirrus profile now, so there is no observable or destructive change to existing deployments.
2. Deploying this change through a standalone cirrus module invocation operates as before but now with the ability to set the `resource_prefix` used across all cirrus resources. 

## Checklist

- [X] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
