### PR TITLE
Add additional security groups to private API GW VPCes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- A list of additional security groups can now be added to the VPCes for PRIVATE-type stac-server and/or cirrus API gateways
+
 ### Changed
 
 ### Fixed

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -39,6 +39,7 @@ stac_server_inputs = {
   cors_methods                                = ""
   cors_headers                                = ""
   authorized_s3_arns                          = []
+  private_api_additional_security_group_ids   = null
   api_lambda                                  = null
   ingest_lambda                               = null
   pre_hook_lambda                             = null
@@ -151,11 +152,12 @@ console_ui_inputs = {
 }
 
 cirrus_inputs = {
-  data_bucket    = "" # If left blank the deployment will create the data bucket
-  payload_bucket = "" # If left blank the deployment will create the payload bucket
-  log_level      = "DEBUG"
-  deploy_alarms  = true
-  api_rest_type  = "EDGE"
+  data_bucket                               = "" # If left blank the deployment will create the data bucket
+  payload_bucket                            = "" # If left blank the deployment will create the payload bucket
+  log_level                                 = "DEBUG"
+  deploy_alarms                             = true
+  api_rest_type                             = "EDGE"
+  private_api_additional_security_group_ids = null
   custom_alarms = {
     warning  = {}
     critical = {}

--- a/default.tfvars
+++ b/default.tfvars
@@ -41,6 +41,7 @@ stac_server_inputs = {
   cors_methods                                = ""
   cors_headers                                = ""
   authorized_s3_arns                          = []
+  private_api_additional_security_group_ids   = null
   api_lambda                                  = null
   ingest_lambda                               = null
   pre_hook_lambda                             = null
@@ -155,11 +156,12 @@ console_ui_inputs = {
 }
 
 cirrus_inputs = {
-  data_bucket    = "" # If left blank the deployment will create the data bucket
-  payload_bucket = "" # If left blank the deployment will create the payload bucket
-  log_level      = "DEBUG"
-  deploy_alarms  = true
-  api_rest_type  = "EDGE"
+  data_bucket                               = "" # If left blank the deployment will create the data bucket
+  payload_bucket                            = "" # If left blank the deployment will create the payload bucket
+  log_level                                 = "DEBUG"
+  deploy_alarms                             = true
+  api_rest_type                             = "EDGE"
+  private_api_additional_security_group_ids = null
   custom_alarms = {
     warning  = {}
     critical = {}

--- a/inputs.tf
+++ b/inputs.tf
@@ -97,6 +97,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
       memory_mb       = optional(number)
@@ -164,6 +165,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null
     pre_hook_lambda                             = null
@@ -362,11 +364,12 @@ variable "console_ui_inputs" {
 variable "cirrus_inputs" {
   description = "Inputs for FilmDrop Cirrus deployment."
   type = object({
-    data_bucket    = string
-    payload_bucket = string
-    log_level      = string
-    api_rest_type  = string
-    deploy_alarms  = bool
+    data_bucket                               = string
+    payload_bucket                            = string
+    log_level                                 = string
+    api_rest_type                             = string
+    private_api_additional_security_group_ids = optional(list(string))
+    deploy_alarms                             = bool
     custom_alarms = object({
       warning  = map(any)
       critical = map(any)
@@ -407,11 +410,12 @@ variable "cirrus_inputs" {
     workflow_definitions_dir           = optional(string)
   })
   default = {
-    data_bucket    = "cirrus-data-bucket-name"
-    payload_bucket = "cirrus-payload-bucket-name"
-    log_level      = "INFO"
-    api_rest_type  = "EDGE"
-    deploy_alarms  = true
+    data_bucket                               = "cirrus-data-bucket-name"
+    payload_bucket                            = "cirrus-payload-bucket-name"
+    log_level                                 = "INFO"
+    api_rest_type                             = "EDGE"
+    private_api_additional_security_group_ids = null
+    deploy_alarms                             = true
     custom_alarms = {
       warning  = {}
       critical = {}

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -151,9 +151,12 @@ resource "aws_vpc_endpoint" "cirrus_api_gateway_private" {
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
   subnet_ids          = data.aws_subnet.selected[*].id
-  security_group_ids  = aws_security_group.cirrus_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false
+  security_group_ids = concat(
+    aws_security_group.cirrus_api_gateway_private_vpce[*].id,
+    coalesce(var.cirrus_private_api_additional_security_group_ids, [])
+  )
 
   dns_options {
     dns_record_ip_type = "ipv4"

--- a/modules/cirrus/builtin-functions/inputs.tf
+++ b/modules/cirrus/builtin-functions/inputs.tf
@@ -141,6 +141,17 @@ variable "cirrus_api_rest_type" {
   default     = "EDGE"
 }
 
+variable "cirrus_private_api_additional_security_group_ids" {
+  description = <<-DESCRIPTION
+  Optional list of security group IDs that'll be applied to the VPC interface
+  endpoints of a PRIVATE-type cirrus API Gateway. These security groups are in
+  addition to the security groups that allow traffic from the private subnet
+  CIDR blocks. Only applicable when `var.cirrus_api_rest_type == PRIVATE`.
+  DESCRIPTION
+  type        = list(string)
+  default     = null
+}
+
 variable "cirrus_api_stage" {
   description = "Cirrus API stage"
   type        = string

--- a/modules/cirrus/builtin_functions.tf
+++ b/modules/cirrus/builtin_functions.tf
@@ -15,6 +15,7 @@ module "builtin_functions" {
   cirrus_payload_bucket                            = module.base.cirrus_payload_bucket
   cirrus_lambda_zip_filepath                       = local.cirrus_lambda_zip_filepath
   cirrus_api_rest_type                             = var.cirrus_api_rest_type
+  cirrus_private_api_additional_security_group_ids = var.cirrus_private_api_additional_security_group_ids
   cirrus_api_lambda_timeout                        = var.cirrus_api_lambda_timeout
   cirrus_api_lambda_memory                         = var.cirrus_api_lambda_memory
   cirrus_process_lambda_timeout                    = var.cirrus_process_lambda_timeout

--- a/modules/cirrus/inputs.tf
+++ b/modules/cirrus/inputs.tf
@@ -74,6 +74,17 @@ variable "cirrus_api_rest_type" {
   default     = "EDGE"
 }
 
+variable "cirrus_private_api_additional_security_group_ids" {
+  description = <<-DESCRIPTION
+  Optional list of security group IDs that'll be applied to the VPC interface
+  endpoints of a PRIVATE-type cirrus API Gateway. These security groups are in
+  addition to the security groups that allow traffic from the private subnet
+  CIDR blocks. Only applicable when `var.cirrus_api_rest_type == PRIVATE`.
+  DESCRIPTION
+  type        = list(string)
+  default     = null
+}
+
 variable "cirrus_api_lambda_timeout" {
   description = "Cirrus API lambda timeout (sec)"
   type        = number

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -88,9 +88,12 @@ resource "aws_vpc_endpoint" "stac_server_api_gateway_private" {
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
   subnet_ids          = data.aws_subnet.selected[*].id
-  security_group_ids  = aws_security_group.stac_server_api_gateway_private_vpce[*].id
   auto_accept         = true
   private_dns_enabled = false
+  security_group_ids = concat(
+    aws_security_group.stac_server_api_gateway_private_vpce[*].id,
+    coalesce(var.private_api_additional_security_group_ids, [])
+  )
 
   dns_options {
     dns_record_ip_type = "ipv4"

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -169,6 +169,17 @@ variable "api_rest_type" {
   default     = "EDGE"
 }
 
+variable "private_api_additional_security_group_ids" {
+  description = <<-DESCRIPTION
+  Optional list of security group IDs that'll be applied to the VPC interface
+  endpoints of a PRIVATE-type stac-server API Gateway. These security groups are
+  in addition to the security groups that allow traffic from the private subnet
+  CIDR blocks. Only applicable when `var.api_rest_type == PRIVATE`.
+  DESCRIPTION
+  type        = list(string)
+  default     = null
+}
+
 variable "opensearch_version" {
   description = "OpenSearch version for OpenSearch Domain"
   type        = string

--- a/profiles/cirrus/inputs.tf
+++ b/profiles/cirrus/inputs.tf
@@ -34,11 +34,12 @@ variable "security_group_id" {
 variable "cirrus_inputs" {
   description = "Inputs for FilmDrop Cirrus deployment"
   type = object({
-    data_bucket    = string
-    payload_bucket = string
-    log_level      = string
-    api_rest_type  = string
-    deploy_alarms  = bool
+    data_bucket                               = string
+    payload_bucket                            = string
+    log_level                                 = string
+    api_rest_type                             = string
+    private_api_additional_security_group_ids = optional(list(string))
+    deploy_alarms                             = bool
     custom_alarms = object({
       warning  = map(any)
       critical = map(any)
@@ -79,11 +80,12 @@ variable "cirrus_inputs" {
     workflow_definitions_dir           = optional(string)
   })
   default = {
-    data_bucket    = "cirrus-data-bucket-name"
-    payload_bucket = "cirrus-payload-bucket-name"
-    log_level      = "INFO"
-    api_rest_type  = "EDGE"
-    deploy_alarms  = true
+    data_bucket                               = "cirrus-data-bucket-name"
+    payload_bucket                            = "cirrus-payload-bucket-name"
+    log_level                                 = "INFO"
+    api_rest_type                             = "EDGE"
+    private_api_additional_security_group_ids = null
+    deploy_alarms                             = true
     custom_alarms = {
       warning  = {}
       critical = {}

--- a/profiles/cirrus/main.tf
+++ b/profiles/cirrus/main.tf
@@ -15,6 +15,7 @@ module "cirrus" {
   cirrus_payload_bucket                                     = var.cirrus_inputs.payload_bucket
   cirrus_log_level                                          = var.cirrus_inputs.log_level
   cirrus_api_rest_type                                      = var.cirrus_inputs.api_rest_type
+  cirrus_private_api_additional_security_group_ids          = var.cirrus_inputs.private_api_additional_security_group_ids
   cirrus_api_lambda_timeout                                 = var.cirrus_inputs.api_lambda.timeout
   cirrus_api_lambda_memory                                  = var.cirrus_inputs.api_lambda.memory
   cirrus_process_lambda_timeout                             = var.cirrus_inputs.process_lambda.timeout

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -97,6 +97,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
       memory_mb       = optional(number)
@@ -164,6 +165,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null
     pre_hook_lambda                             = null
@@ -362,11 +364,12 @@ variable "console_ui_inputs" {
 variable "cirrus_inputs" {
   description = "Inputs for FilmDrop Cirrus deployment."
   type = object({
-    data_bucket    = string
-    payload_bucket = string
-    log_level      = string
-    api_rest_type  = string
-    deploy_alarms  = bool
+    data_bucket                               = string
+    payload_bucket                            = string
+    log_level                                 = string
+    api_rest_type                             = string
+    private_api_additional_security_group_ids = optional(list(string))
+    deploy_alarms                             = bool
     custom_alarms = object({
       warning  = map(any)
       critical = map(any)
@@ -407,11 +410,12 @@ variable "cirrus_inputs" {
     workflow_definitions_dir           = optional(string)
   })
   default = {
-    data_bucket    = "cirrus-data-bucket-name"
-    payload_bucket = "cirrus-payload-bucket-name"
-    log_level      = "INFO"
-    api_rest_type  = "EDGE"
-    deploy_alarms  = true
+    data_bucket                               = "cirrus-data-bucket-name"
+    payload_bucket                            = "cirrus-payload-bucket-name"
+    log_level                                 = "INFO"
+    api_rest_type                             = "EDGE"
+    private_api_additional_security_group_ids = null
+    deploy_alarms                             = true
     custom_alarms = {
       warning  = {}
       critical = {}

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -60,6 +60,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
       memory_mb       = optional(number)
@@ -127,6 +128,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null
     pre_hook_lambda                             = null

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -17,6 +17,7 @@ module "stac-server" {
   additional_ingest_sqs_senders_arns          = var.stac_server_inputs.additional_ingest_sqs_senders_arns
   opensearch_ebs_volume_size                  = var.stac_server_inputs.opensearch_ebs_volume_size
   api_rest_type                               = var.stac_server_inputs.api_rest_type
+  private_api_additional_security_group_ids   = var.stac_server_inputs.private_api_additional_security_group_ids
   api_lambda                                  = var.stac_server_inputs.api_lambda
   ingest_lambda                               = var.stac_server_inputs.ingest_lambda
   pre_hook_lambda                             = var.stac_server_inputs.pre_hook_lambda


### PR DESCRIPTION
Adds a variable for an optional list of security group IDs that'll be applied to the VPC interface endpoints of a PRIVATE-type cirrus and/or stac-server API Gateway. These security groups are in addition to the security groups that allow traffic from the private subnet CIDR blocks. Only applicable when the api_rest_type == PRIVATE. Defaults to null.