### PR TITLE
Add stac_version input variable to stac-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Cirrus workflows can now invoke any AWS service that provides a state machine integration
 - The cirrus `task-batch-compute` submodule now supports parameterization of its definition YAMLs through templating
 - The cirrus `workflow` submodule now supports parameterization of its definition YAMLs and state machine JSONs through templating
+- The `stac-server` API's `STAC_VERSION` environment variable can now be specified via input variable `stac_version`
 
 ### Changed
 

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -20,6 +20,7 @@ sns_critical_subscriptions_map = {}
 stac_server_inputs = {
   app_name                                    = "stac_server"
   version                                     = "v3.8.0"
+  stac_version                                = "1.0.0"
   deploy_cloudfront                           = false
   api_rest_type                               = "EDGE"
   web_acl_id                                  = ""

--- a/default.tfvars
+++ b/default.tfvars
@@ -22,6 +22,7 @@ sns_critical_subscriptions_map = {}
 stac_server_inputs = {
   app_name                                    = "stac_server"
   version                                     = "v3.8.0"
+  stac_version                                = "1.0.0"
   api_rest_type                               = "EDGE"
   deploy_cloudfront                           = true
   web_acl_id                                  = ""

--- a/inputs.tf
+++ b/inputs.tf
@@ -78,6 +78,7 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
+    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -146,6 +147,7 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
+    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -19,6 +19,7 @@ resource "aws_lambda_function" "stac_server_api" {
       STAC_ID                 = var.stac_id
       STAC_TITLE              = var.stac_title
       STAC_DESCRIPTION        = var.stac_description
+      STAC_VERSION            = var.stac_version
       LOG_LEVEL               = var.log_level
       REQUEST_LOGGING_ENABLED = var.request_logging_enabled
       STAC_DOCS_URL           = var.stac_docs_url

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -4,6 +4,15 @@ variable "stac_id" {
   default     = "stac-server"
 }
 
+variable "stac_version" {
+  description = <<-DESCRIPTION
+  (Optional) STAC version string. Maps to stac-server's `STAC_VERSION` environment variable.
+  DESCRIPTION
+  type        = string
+  nullable    = false
+  default     = "1.0.0"
+}
+
 variable "stac_title" {
   description = "STAC title"
   type        = string

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -78,6 +78,7 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
+    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -146,6 +147,7 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
+    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -41,6 +41,7 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
+    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -109,6 +110,7 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
+    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -6,6 +6,7 @@ module "stac-server" {
   vpc_subnet_ids                              = var.private_subnet_ids
   vpc_security_group_ids                      = [var.security_group_id]
   stac_api_stage                              = var.environment
+  stac_version                                = var.stac_server_inputs.stac_version
   enable_transactions_extension               = var.stac_server_inputs.enable_transactions_extension
   collection_to_index_mappings                = var.stac_server_inputs.collection_to_index_mappings
   opensearch_cluster_instance_type            = var.stac_server_inputs.opensearch_cluster_instance_type


### PR DESCRIPTION
Adds `stac_version` input variable to be used as the `STAC_VERSION` environment variable in the `stac-server` API. See:
https://github.com/stac-utils/stac-server?tab=readme-ov-file#deployment