### PR TITLE
Expose stac-server lambda iam role arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Exposing stac_server_ingest_sns_topic_arn via outputs
+- Exposed stac_server_lambda_iam_role_arn via outputs
 
 ## [2.38.0] - 2025-03-20
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -173,3 +173,7 @@ output "stac_server_ingest_sns_topic_arn" {
 output "stac_server_post_ingest_sns_topic_arn" {
   value = module.filmdrop.stac_server_post_ingest_sns_topic_arn
 }
+
+output "stac_server_lambda_iam_role_arn" {
+  value = module.filmdrop.stac_server_lambda_iam_role_arn
+}

--- a/profiles/core/outputs.tf
+++ b/profiles/core/outputs.tf
@@ -173,3 +173,7 @@ output "stac_server_ingest_sns_topic_arn" {
 output "stac_server_post_ingest_sns_topic_arn" {
   value = var.deploy_stac_server ? module.stac-server[0].stac_server_post_ingest_sns_topic_arn : ""
 }
+
+output "stac_server_lambda_iam_role_arn" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_lambda_iam_role_arn : ""
+}

--- a/profiles/stac-server/outputs.tf
+++ b/profiles/stac-server/outputs.tf
@@ -25,3 +25,7 @@ output "stac_server_ingest_sns_topic_arn" {
 output "stac_server_post_ingest_sns_topic_arn" {
   value = module.stac-server.stac_server_post_ingest_sns_topic_arn
 }
+
+output "stac_server_lambda_iam_role_arn" {
+  value = module.stac-server.stac_server_lambda_iam_role_arn
+}


### PR DESCRIPTION
## Proposed Changes

1. Exposes stac_server_lambda_iam_role_arn through outputs


## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
