### PR TITLE
remove stac_version configuration parameter for stac-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+- `stac_version` is no longer supported for configuration
+
 ## [2.39.0] - 2025-03-21
 
 ### Added

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -20,7 +20,6 @@ sns_critical_subscriptions_map = {}
 stac_server_inputs = {
   app_name                                    = "stac_server"
   version                                     = "v3.8.0"
-  stac_version                                = "1.0.0"
   deploy_cloudfront                           = false
   api_rest_type                               = "EDGE"
   web_acl_id                                  = ""

--- a/default.tfvars
+++ b/default.tfvars
@@ -22,7 +22,6 @@ sns_critical_subscriptions_map = {}
 stac_server_inputs = {
   app_name                                    = "stac_server"
   version                                     = "v3.8.0"
-  stac_version                                = "1.0.0"
   api_rest_type                               = "EDGE"
   deploy_cloudfront                           = true
   web_acl_id                                  = ""

--- a/inputs.tf
+++ b/inputs.tf
@@ -78,7 +78,6 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
-    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -148,7 +147,6 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
-    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -19,7 +19,6 @@ resource "aws_lambda_function" "stac_server_api" {
       STAC_ID                 = var.stac_id
       STAC_TITLE              = var.stac_title
       STAC_DESCRIPTION        = var.stac_description
-      STAC_VERSION            = var.stac_version
       LOG_LEVEL               = var.log_level
       REQUEST_LOGGING_ENABLED = var.request_logging_enabled
       STAC_DOCS_URL           = var.stac_docs_url

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -4,15 +4,6 @@ variable "stac_id" {
   default     = "stac-server"
 }
 
-variable "stac_version" {
-  description = <<-DESCRIPTION
-  (Optional) STAC version string. Maps to stac-server's `STAC_VERSION` environment variable.
-  DESCRIPTION
-  type        = string
-  nullable    = false
-  default     = "1.0.0"
-}
-
 variable "stac_title" {
   description = "STAC title"
   type        = string

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -78,7 +78,6 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
-    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -148,7 +147,6 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
-    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -41,7 +41,6 @@ variable "stac_server_inputs" {
   type = object({
     app_name                                    = string
     version                                     = string
-    stac_version                                = optional(string)
     deploy_cloudfront                           = bool
     web_acl_id                                  = string
     domain_alias                                = string
@@ -111,7 +110,6 @@ variable "stac_server_inputs" {
   default = {
     app_name                                    = "stac_server"
     version                                     = "v3.8.0"
-    stac_version                                = "1.0.0"
     deploy_cloudfront                           = true
     web_acl_id                                  = ""
     domain_alias                                = ""

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -6,7 +6,6 @@ module "stac-server" {
   vpc_subnet_ids                              = var.private_subnet_ids
   vpc_security_group_ids                      = [var.security_group_id]
   stac_api_stage                              = var.environment
-  stac_version                                = var.stac_server_inputs.stac_version
   enable_transactions_extension               = var.stac_server_inputs.enable_transactions_extension
   collection_to_index_mappings                = var.stac_server_inputs.collection_to_index_mappings
   opensearch_cluster_instance_type            = var.stac_server_inputs.opensearch_cluster_instance_type


### PR DESCRIPTION
## Related issue(s)

n/a

## Proposed Changes

1. Remove the "stac_version" configuration parameter. This was only added because of a misunderstanding of what it controlled and a bug in stac-server, which has since been fixed. It is more likely to confuse future users as to what it controls (only the stac_version parameter of the landing page) and make them think it controls the version on the STAC Items that exist in the server. Therefore, removing.

## Testing

This change was validated by the following observations:

- untested, reverted commit

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
