### PR TITLE
set opensearch_version to be optional

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -83,7 +83,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     collection_to_index_mappings                = string
-    opensearch_version                          = string
+    opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
     opensearch_cluster_instance_count           = number
     opensearch_cluster_dedicated_master_enabled = bool

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -83,7 +83,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     collection_to_index_mappings                = string
-    opensearch_version                          = string
+    opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
     opensearch_cluster_instance_count           = number
     opensearch_cluster_dedicated_master_enabled = bool

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -46,7 +46,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     collection_to_index_mappings                = string
-    opensearch_version                          = string
+    opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
     opensearch_cluster_instance_count           = number
     opensearch_cluster_dedicated_master_enabled = bool


### PR DESCRIPTION
## Related issue(s)

n/a

## Proposed Changes

1. set stac_server.opensearch_version to be optional

## Testing

This change was validated by the following observations:

- code change only, not deployed

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [ ] I have added my changes to the changelog
  - [X] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
