### PR TITLE
fix(cirrus): api lambda role had incorrect index resource spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Corrected resource string for `cirrus` API lambda function role to access
+  `StateDB` indexes.
+
 ### Removed
 
 - `stac_version` is no longer supported for configuration

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "cirrus_api_lambda_policy" {
       ],
       "Resource": [
         "${var.cirrus_state_dynamodb_table_arn}",
-        "${var.cirrus_state_dynamodb_table_arn}/index.*"
+        "${var.cirrus_state_dynamodb_table_arn}/index/*"
       ]
     },
     {


### PR DESCRIPTION
## Related issue(s)

- undocumented

Encountered permission issue in a deployment when using the dashboard.

## Proposed Changes

1. (see diff) dynamo indexes are under `${table}/index/*`, not `${table}/index.*`

## Testing

This change was validated by the following observations:

1. Inspecting the permissions string of Serverless-based cirrus deployments.

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary
