### PR TITLE
expose stac-server gateway id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added configuration `stac_server_inputs.opensearch_version`
+- Added output for stac-server gateway id
 
 ### Changed
 

--- a/modules/stac-server/outputs.tf
+++ b/modules/stac-server/outputs.tf
@@ -61,3 +61,7 @@ output "stac_server_ingest_sns_topic_arn" {
 output "stac_server_post_ingest_sns_topic_arn" {
   value = aws_sns_topic.stac_server_post_ingest_sns_topic.arn
 }
+
+output "stac_server_api_gateway_id" {
+  value = aws_api_gateway_rest_api.stac_server_api_gateway.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -177,3 +177,7 @@ output "stac_server_post_ingest_sns_topic_arn" {
 output "stac_server_lambda_iam_role_arn" {
   value = module.filmdrop.stac_server_lambda_iam_role_arn
 }
+
+output "stac_server_api_gateway_id" {
+  value = module.filmdrop.stac_server_api_gateway_id
+}

--- a/profiles/core/outputs.tf
+++ b/profiles/core/outputs.tf
@@ -177,3 +177,8 @@ output "stac_server_post_ingest_sns_topic_arn" {
 output "stac_server_lambda_iam_role_arn" {
   value = var.deploy_stac_server ? module.stac-server[0].stac_server_lambda_iam_role_arn : ""
 }
+
+
+output "stac_server_api_gateway_id" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_api_gateway_id : ""
+}

--- a/profiles/stac-server/outputs.tf
+++ b/profiles/stac-server/outputs.tf
@@ -29,3 +29,7 @@ output "stac_server_post_ingest_sns_topic_arn" {
 output "stac_server_lambda_iam_role_arn" {
   value = module.stac-server.stac_server_lambda_iam_role_arn
 }
+
+output "stac_server_api_gateway_id" {
+  value = module.stac-server.stac_server_api_gateway_id
+}


### PR DESCRIPTION
## Related issue(s)

- N/A

## Proposed Changes

1. exposes stac-server gateway id as an output from stac-server/filmdrop module

## Testing

This change was validated by the following observations:

1. N/A

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary