### PR TITLE
fix(update-state,process): correct dynamodb table indexes resource string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Corrected resource string for `update-state` and `process` lambda function
+  roles to access `StateDB` indexes.
+
 ### Removed
 
 ## [2.40.0] - 2025-03-24

--- a/modules/cirrus/builtin-functions/process.tf
+++ b/modules/cirrus/builtin-functions/process.tf
@@ -56,7 +56,7 @@ resource "aws_iam_policy" "cirrus_process_lambda_policy" {
       ],
       "Resource": [
         "${var.cirrus_state_dynamodb_table_arn}",
-        "${var.cirrus_state_dynamodb_table_arn}/index.*"
+        "${var.cirrus_state_dynamodb_table_arn}/index/*"
       ]
     },
     {

--- a/modules/cirrus/builtin-functions/update-state.tf
+++ b/modules/cirrus/builtin-functions/update-state.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "cirrus_update_state_lambda_policy" {
       ],
       "Resource": [
         "${var.cirrus_state_dynamodb_table_arn}",
-        "${var.cirrus_state_dynamodb_table_arn}/index.*"
+        "${var.cirrus_state_dynamodb_table_arn}/index/*"
       ]
     },
     {


### PR DESCRIPTION
## Related issue(s)

- Follow on from #121 

## Proposed Changes

Either correct the strings as in 61909b0, or drop those permissions (as they seem unnecessary for functioning) for least-privilege principle reasons.
1. 

## Testing

Not yet tested.

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
