### PR TITLE
allow stac-server module to configure api gateway authorization type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added input to allow configuration of stac-server api gateway method authorization type
+
 ### Changed
 
 ### Fixed

--- a/inputs.tf
+++ b/inputs.tf
@@ -99,6 +99,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    api_method_authorization_type               = optional(string)
     private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
@@ -169,6 +170,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    api_method_authorization_type               = "NONE"
     private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -154,7 +154,7 @@ resource "aws_api_gateway_method" "stac_server_api_gateway_root_method" {
   rest_api_id   = aws_api_gateway_rest_api.stac_server_api_gateway.id
   resource_id   = aws_api_gateway_rest_api.stac_server_api_gateway.root_resource_id
   http_method   = "ANY"
-  authorization = "NONE"
+  authorization = var.api_method_authorization_type
 }
 
 resource "aws_api_gateway_integration" "stac_server_api_gateway_root_method_integration" {
@@ -176,14 +176,14 @@ resource "aws_api_gateway_method" "stac_server_api_gateway_proxy_resource_method
   rest_api_id   = aws_api_gateway_rest_api.stac_server_api_gateway.id
   resource_id   = aws_api_gateway_resource.stac_server_api_gateway_proxy_resource.id
   http_method   = "ANY"
-  authorization = "NONE"
+  authorization = var.api_method_authorization_type
 }
 
 resource "aws_api_gateway_method" "stac_root_options_method" {
   rest_api_id   = aws_api_gateway_rest_api.stac_server_api_gateway.id
   resource_id   = aws_api_gateway_rest_api.stac_server_api_gateway.root_resource_id
   http_method   = "OPTIONS"
-  authorization = "NONE"
+  authorization = var.api_method_authorization_type
 }
 resource "aws_api_gateway_method_response" "stac_root_options_200" {
   rest_api_id = aws_api_gateway_rest_api.stac_server_api_gateway.id
@@ -221,7 +221,7 @@ resource "aws_api_gateway_method" "stac_options_method" {
   rest_api_id   = aws_api_gateway_rest_api.stac_server_api_gateway.id
   resource_id   = aws_api_gateway_resource.stac_server_api_gateway_proxy_resource.id
   http_method   = "OPTIONS"
-  authorization = "NONE"
+  authorization = var.api_method_authorization_type
 }
 resource "aws_api_gateway_method_response" "stac_options_200" {
   rest_api_id = aws_api_gateway_rest_api.stac_server_api_gateway.id

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -169,6 +169,17 @@ variable "api_rest_type" {
   default     = "EDGE"
 }
 
+variable "api_method_authorization_type" {
+  description = "STAC API Gateway method authorization type"
+  type        = string
+  default     = "NONE"
+
+  validation {
+    condition     = contains(["NONE", "CUSTOM", "AWS_IAM", "COGNITO_USER_POOLS"], var.api_method_authorization_type)
+    error_message = "STAC API method authorization type must be one of: NONE, CUSTOM, AWS_IAM, or COGNITO_USER_POOLS."
+  }
+}
+
 variable "private_api_additional_security_group_ids" {
   description = <<-DESCRIPTION
   Optional list of security group IDs that'll be applied to the VPC interface

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -99,6 +99,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    api_method_authorization_type               = optional(string)
     private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
@@ -169,6 +170,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    api_method_authorization_type               = "NONE"
     private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -62,6 +62,7 @@ variable "stac_server_inputs" {
     cors_headers                                = string
     authorized_s3_arns                          = list(string)
     api_rest_type                               = string
+    api_method_authorization_type               = optional(string)
     private_api_additional_security_group_ids   = optional(list(string))
     api_lambda = optional(object({
       handler         = optional(string)
@@ -132,6 +133,7 @@ variable "stac_server_inputs" {
     cors_headers                                = ""
     authorized_s3_arns                          = []
     api_rest_type                               = "EDGE"
+    api_method_authorization_type               = "NONE"
     private_api_additional_security_group_ids   = null
     api_lambda                                  = null
     ingest_lambda                               = null

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -19,6 +19,7 @@ module "stac-server" {
   ingest_sns_topic_arns                       = var.stac_server_inputs.ingest_sns_topic_arns
   additional_ingest_sqs_senders_arns          = var.stac_server_inputs.additional_ingest_sqs_senders_arns
   api_rest_type                               = var.stac_server_inputs.api_rest_type
+  api_method_authorization_type               = var.stac_server_inputs.api_method_authorization_type
   private_api_additional_security_group_ids   = var.stac_server_inputs.private_api_additional_security_group_ids
   api_lambda                                  = var.stac_server_inputs.api_lambda
   ingest_lambda                               = var.stac_server_inputs.ingest_lambda


### PR DESCRIPTION
## Related issue(s)

- N/A

## Proposed Changes

1. Add a new input for stac-server to allow the configuration of api gateway method authorization type ([method ref](https://docs.aws.amazon.com/apigateway/latest/api/API_Method.html))

## Testing

This change was validated by the following observations:

1. N/A

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
