### PR TITLE
(fix): add default api gateway method to tfvars

### DIFF
--- a/ci.tfvars
+++ b/ci.tfvars
@@ -22,6 +22,7 @@ stac_server_inputs = {
   version                                     = "v3.10.0"
   deploy_cloudfront                           = false
   api_rest_type                               = "EDGE"
+  api_method_authorization_type               = "NONE"
   web_acl_id                                  = ""
   domain_alias                                = ""
   enable_transactions_extension               = false

--- a/default.tfvars
+++ b/default.tfvars
@@ -23,6 +23,7 @@ stac_server_inputs = {
   app_name                                    = "stac_server"
   version                                     = "v3.10.0"
   api_rest_type                               = "EDGE"
+  api_method_authorization_type               = "NONE"
   deploy_cloudfront                           = true
   web_acl_id                                  = ""
   domain_alias                                = ""


### PR DESCRIPTION
## Related issue(s)

- In #127, ci and default tfvars should have included the default api gateway method authorization type. 

## Proposed Changes

1. Update ci and default tfvars to have default api gateway method authorization type

## Testing

This change was validated by the following observations:

1. N/A

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary