### PR TITLE
Fix/tr/nops 195/sqs sender role assumption

### DIFF
--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -4,7 +4,7 @@ locals {
   non_role_arns = concat(
     [aws_sns_topic.stac_server_ingest_sns_topic.arn],
     var.ingest_sns_topic_arns, [
-      for item in var.additional_ingest_sqs_senders_arns : item if !contains(role_arns, item)
+      for item in var.additional_ingest_sqs_senders_arns : item if !contains(local.role_arns, item)
   ])
 }
 
@@ -82,9 +82,8 @@ resource "aws_sqs_queue_policy" "stac_server_ingest_sqs_queue_policy" {
 }
 
 data "aws_iam_policy_document" "stac_server_ingest_sqs_policy" {
-  count = local.is_private_endpoint ? 1 : 0
 
-  # SNS + everything else allowables statement block
+  # handle SNS + non-assumed roles
   statement {
     effect = "Allow"
 
@@ -107,7 +106,7 @@ data "aws_iam_policy_document" "stac_server_ingest_sqs_policy" {
     }
   }
 
-  # ROLE assumptions statement block
+  # handle STS role assumption
   statement {
     effect = "Allow"
 

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -1,5 +1,5 @@
 locals {
-  role_arns = [for item in var.additional_ingest_sqs_senders_arns : item if regexall("^arn:[a-z-]+:iam::\\d{12}:role", item) > 0]
+  role_arns = [for item in var.additional_ingest_sqs_senders_arns : item if length(regexall("^arn:[a-z-]+:iam::\\d{12}:role", item)) > 0]
 
   non_role_arns = concat(
     [aws_sns_topic.stac_server_ingest_sns_topic.arn],

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -1,3 +1,10 @@
+locals {
+  values = concat([aws_sns_topic.stac_server_ingest_sns_topic.arn], var.ingest_sns_topic_arns, var.additional_ingest_sqs_senders_arns)
+
+  role_arns = [for item in local.values : item if length(regex("role", item)) > 0]
+  sns_arns  = [for item in local.values : item if !contains(role_arns, item)]
+}
+
 resource "aws_lambda_function" "stac_server_ingest" {
   filename                       = local.resolved_ingest_lambda_zip_filepath
   function_name                  = "${local.name_prefix}-stac-server-ingest"
@@ -72,27 +79,50 @@ resource "aws_sqs_queue_policy" "stac_server_ingest_sqs_queue_policy" {
 }
 
 data "aws_iam_policy_document" "stac_server_ingest_sqs_policy" {
+  count = local.is_private_endpoint ? 1 : 0
+
+  # SNS allowables statement block
   statement {
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["sns.amazonaws.com"]
     }
 
     actions = [
       "sqs:SendMessage"
     ]
 
-    resources = [
-      aws_sqs_queue.stac_server_ingest_sqs_queue.arn,
-    ]
+    resources = [aws_sqs_queue.stac_server_ingest_sqs_queue.arn]
 
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
 
-      values = concat([aws_sns_topic.stac_server_ingest_sns_topic.arn], var.ingest_sns_topic_arns, var.additional_ingest_sqs_senders_arns)
+      values = local.sns_arns
+    }
+  }
+
+  # ROLE assumptions statement block
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["a"]
+
+    }
+    actions = [
+      "sqs:SendMessage"
+    ]
+    resources = [aws_sqs_queue.stac_server_ingest_sqs_queue.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws.SourceArn"
+
+      values = local.role_arns
     }
   }
 }

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "stac_server_ingest_sqs_policy" {
     }
   }
 
-  # handle roles - both direct used or assumed by STS
+  # handle roles - both directly used or assumed by STS
   dynamic "statement" {
     for_each = local.role_arns
     content {

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -380,6 +380,7 @@ variable "additional_ingest_sqs_senders_arns" {
   description = "List of additional principals to grant access to send to the Ingest SQS. This is required to allow STAC API SNS notifications (e.g. earth search's ingest SNS topic) to be able to publish SQS ingest messages to our stac-server for indexing."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "project_name" {


### PR DESCRIPTION
## Related issue(s)

- NOPS-195 

## Proposed Changes

1. Fix an issue with inputs to stac-server innput variable  where input arns can be either SNS topics or roles.  We are currently using a wildcard princial to use and access them.   This fix creates two lists, one for STS role assumptions an another for SNS and all other non-assumed roles.

## Testing

This change was validated by the following observations:

1.

## Checklist

- [ ] I have deployed and validated this change
- [ ] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
