### PR TITLE
fix: remove now outdated permisson from update state cirruc lambda + bump default cirrus to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- removing step functon permission from `update-state` IAM policy due to change in how 
+  `update-state` lambda gets errors
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added inputs to configure stac_id, stac_title, stac_description, and enable_collections_authx
-
 ### Changed
 
 ### Fixed
 
 ### Removed
+
+## [2.42.0] - 2025-04-08
+
+### Added
+
+- Added inputs to configure stac_id, stac_title, stac_description, and enable_collections_authx
 
 ## [2.41.0] - 2025-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- removing step functon permission from `update-state` IAM policy due to change in how 
+- removing step function permission from `update-state` IAM policy due to change in how 
   `update-state` lambda gets errors in cirrus v1.0.0 release
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - removing step functon permission from `update-state` IAM policy due to change in how 
-  `update-state` lambda gets errors
+  `update-state` lambda gets errors in cirrus v1.0.0 release
 
 ### Fixed
 

--- a/modules/cirrus/builtin-functions/update-state.tf
+++ b/modules/cirrus/builtin-functions/update-state.tf
@@ -57,13 +57,6 @@ resource "aws_iam_policy" "cirrus_update_state_lambda_policy" {
     {
       "Effect": "Allow",
       "Action": [
-        "states:GetExecutionHistory"
-      ],
-      "Resource": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "sqs:SendMessage"
       ],
       "Resource": "${var.cirrus_process_sqs_queue_arn}"


### PR DESCRIPTION
Removing a IAM permission for the `update-state` lambda.

The old permission was necessary to allow the lambda to explore the execution history to dig up batch errors.  A breaking change to this functionality was made in cirrus 1.0.0 where errors are now pulled out of the FAIL state (dependant on user set up of state machines).  This new design makes this execution history permission unnecessary

Pulled in the new cirrus lambda dist zip file from the 1.0.0 release to update cirrus.

## Related issue(s
changes to `update-state` lambda can be seen here
https://github.com/cirrus-geo/cirrus-geo/pull/311/files

-

## Proposed Changes

1.

## Testing

This change was validated by the following observations:

1.

## Checklist

- [ ] I have deployed and validated this change
- [ ] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ x] No migration is necessary
