### PR TITLE
add stac-server enable_ingest_action_truncate configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Input to configure stac-server with ENABLE_INGEST_ACTION_TRUNCATE
+
 ### Changed
 
 ### Fixed
+
+- The variable `enable_collections_authx` defaulted to true, should have defaulted to false.
 
 ### Removed
 
@@ -19,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added inputs to configure stac_id, stac_title, stac_description, and enable_collections_authx
+- Added inputs to configure stac-server with stac_id, stac_title, stac_description, and enable_collections_authx
 
 ## [2.41.0] - 2025-03-27
 

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -30,6 +30,7 @@ stac_server_inputs = {
   domain_alias                                = ""
   enable_transactions_extension               = false
   enable_collections_authx                    = false
+  enable_ingest_action_truncate               = false
   collection_to_index_mappings                = ""
   opensearch_version                          = "OpenSearch_2.17"
   opensearch_cluster_instance_type            = "t3.small.search"

--- a/default.tfvars
+++ b/default.tfvars
@@ -32,6 +32,7 @@ stac_server_inputs = {
   domain_alias                                = ""
   enable_transactions_extension               = false
   enable_collections_authx                    = false
+  enable_ingest_action_truncate               = false
   collection_to_index_mappings                = ""
   opensearch_version                          = "OpenSearch_2.17"
   opensearch_cluster_instance_type            = "t3.small.search"

--- a/inputs.tf
+++ b/inputs.tf
@@ -86,6 +86,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     enable_collections_authx                    = bool
+    enable_ingest_action_truncate               = bool
     collection_to_index_mappings                = string
     opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
@@ -161,6 +162,7 @@ variable "stac_server_inputs" {
     domain_alias                                = ""
     enable_transactions_extension               = false
     enable_collections_authx                    = false
+    enable_ingest_action_truncate               = false
     collection_to_index_mappings                = ""
     opensearch_version                          = "OpenSearch_2.17"
     opensearch_cluster_instance_type            = "t3.small.search"

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -29,6 +29,7 @@ resource "aws_lambda_function" "stac_server_api" {
       )
       ENABLE_TRANSACTIONS_EXTENSION = var.enable_transactions_extension
       ENABLE_COLLECTIONS_AUTHX      = var.enable_collections_authx
+      ENABLE_INGEST_ACTION_TRUNCATE = var.enable_ingest_action_truncate
       STAC_API_ROOTPATH = (
         var.stac_api_rootpath != null
         ? var.stac_api_rootpath

--- a/modules/stac-server/inputs.tf
+++ b/modules/stac-server/inputs.tf
@@ -52,7 +52,13 @@ variable "enable_transactions_extension" {
 variable "enable_collections_authx" {
   description = "Enable Collections Authx"
   type        = string
-  default     = true
+  default     = false
+}
+
+variable "enable_ingest_action_truncate" {
+  description = "Enable Ingest Action Truncate"
+  type        = string
+  default     = false
 }
 
 variable "stac_api_stage" {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -86,6 +86,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     enable_collections_authx                    = bool
+    enable_ingest_action_truncate               = bool
     collection_to_index_mappings                = string
     opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
@@ -161,6 +162,7 @@ variable "stac_server_inputs" {
     domain_alias                                = ""
     enable_transactions_extension               = false
     enable_collections_authx                    = false
+    enable_ingest_action_truncate               = false
     collection_to_index_mappings                = ""
     opensearch_version                          = "OpenSearch_2.17"
     opensearch_cluster_instance_type            = "t3.small.search"

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -49,6 +49,7 @@ variable "stac_server_inputs" {
     domain_alias                                = string
     enable_transactions_extension               = bool
     enable_collections_authx                    = bool
+    enable_ingest_action_truncate               = bool
     collection_to_index_mappings                = string
     opensearch_version                          = optional(string)
     opensearch_cluster_instance_type            = string
@@ -124,6 +125,7 @@ variable "stac_server_inputs" {
     domain_alias                                = ""
     enable_transactions_extension               = false
     enable_collections_authx                    = false
+    enable_ingest_action_truncate               = false
     collection_to_index_mappings                = ""
     opensearch_version                          = "OpenSearch_2.17"
     opensearch_cluster_instance_type            = "t3.small.search"

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -11,6 +11,7 @@ module "stac-server" {
   stac_description                            = var.stac_server_inputs.stac_description
   enable_transactions_extension               = var.stac_server_inputs.enable_transactions_extension
   enable_collections_authx                    = var.stac_server_inputs.enable_collections_authx
+  enable_ingest_action_truncate               = var.stac_server_inputs.enable_ingest_action_truncate
   collection_to_index_mappings                = var.stac_server_inputs.collection_to_index_mappings
   opensearch_version                          = var.stac_server_inputs.opensearch_version
   opensearch_cluster_instance_type            = var.stac_server_inputs.opensearch_cluster_instance_type


### PR DESCRIPTION
## Related issue(s)

- https://github.com/stac-utils/stac-server/pull/891

## Proposed Changes

1. add configuration for enable_ingest_action_truncate env var
2. changed the default of the variable definition of the collection_authn to be false instead of true. All of the uses of this already correctly defaulted to false, so this doesn't change the actual behavior.

## Testing

This change was validated by the following observations:

1. n/a will validate on project deploy

## Checklist

- [ ] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
