### PR TITLE
fix ingest action env var ingest lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- stac_server: set ENABLE_INGEST_ACTION_TRUNCATE on the ingest lambda rather than the api lambda
+
 ### Removed
 
 ## [2.43.0] - 2025-04-30

--- a/modules/stac-server/api.tf
+++ b/modules/stac-server/api.tf
@@ -29,7 +29,6 @@ resource "aws_lambda_function" "stac_server_api" {
       )
       ENABLE_TRANSACTIONS_EXTENSION = var.enable_transactions_extension
       ENABLE_COLLECTIONS_AUTHX      = var.enable_collections_authx
-      ENABLE_INGEST_ACTION_TRUNCATE = var.enable_ingest_action_truncate
       STAC_API_ROOTPATH = (
         var.stac_api_rootpath != null
         ? var.stac_api_rootpath

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "stac_server_ingest" {
       CORS_CREDENTIALS                 = var.cors_credentials
       CORS_METHODS                     = var.cors_methods
       CORS_HEADERS                     = var.cors_headers
-      ENABLE_INGEST_ACTION_TRUNCATE = var.enable_ingest_action_truncate
+      ENABLE_INGEST_ACTION_TRUNCATE    = var.enable_ingest_action_truncate
     }
   }
 

--- a/modules/stac-server/ingest.tf
+++ b/modules/stac-server/ingest.tf
@@ -32,6 +32,7 @@ resource "aws_lambda_function" "stac_server_ingest" {
       CORS_CREDENTIALS                 = var.cors_credentials
       CORS_METHODS                     = var.cors_methods
       CORS_HEADERS                     = var.cors_headers
+      ENABLE_INGEST_ACTION_TRUNCATE = var.enable_ingest_action_truncate
     }
   }
 


### PR DESCRIPTION
## Related issue(s)

- n/a

## Proposed Changes

1. Apply the environment variable ENABLE_INGEST_ACTION_TRUNCATE to the ingest ingest lambda where it's actually used, instead of the api lambda where it is not.

## Testing

This change was validated by the following observations:

1. n/a

## Checklist

- [X] I have deployed and validated this change
- [X] Changelog
  - [X] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [X] README migration
  - [ ] I have added any migration steps to the Readme
  - [X] No migration is necessary
