### PR TITLE
Feat/we/stac server lambda outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Created outputs for the stac-server ingest and api lambda functions including their name and arn.
+
 ### Changed
 
 ### Fixed

--- a/modules/stac-server/outputs.tf
+++ b/modules/stac-server/outputs.tf
@@ -65,3 +65,19 @@ output "stac_server_post_ingest_sns_topic_arn" {
 output "stac_server_api_gateway_id" {
   value = aws_api_gateway_rest_api.stac_server_api_gateway.id
 }
+
+output "stac_server_ingest_lambda_name" {
+  value = aws_lambda_function.stac_server_ingest.function_name
+}
+
+output "stac_server_ingest_lambda_arn" {
+  value = aws_lambda_function.stac_server_ingest.arn
+}
+
+output "stac_server_api_lambda_name" {
+  value = aws_lambda_function.stac_server_api.function_name
+}
+
+output "stac_server_api_lambda_arn" {
+  value = aws_lambda_function.stac_server_api.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -182,6 +182,23 @@ output "stac_server_api_gateway_id" {
   value = module.filmdrop.stac_server_api_gateway_id
 }
 
+output "stac_server_ingest_lambda_name" {
+  value = module.filmdrop.stac_server_ingest_lambda_name
+}
+
+output "stac_server_ingest_lambda_arn" {
+  value = module.filmdrop.stac_server_ingest_lambda_arn
+}
+
+output "stac_server_api_lambda_name" {
+  value = module.filmdrop.stac_server_api_lambda_name
+}
+
+output "stac_server_api_lambda_arn" {
+  value = module.filmdrop.stac_server_api_lambda_arn
+}
+
+
 output "console_ui_bucket_name" {
   value = module.filmdrop.console_ui_bucket_name
 }

--- a/profiles/core/outputs.tf
+++ b/profiles/core/outputs.tf
@@ -183,6 +183,23 @@ output "stac_server_api_gateway_id" {
   value = var.deploy_stac_server ? module.stac-server[0].stac_server_api_gateway_id : ""
 }
 
+output "stac_server_ingest_lambda_name" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_ingest_lambda_name : ""
+}
+
+output "stac_server_ingest_lambda_arn" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_ingest_lambda_arn : ""
+}
+
+output "stac_server_api_lambda_name" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_api_lambda_name : ""
+}
+
+output "stac_server_api_lambda_arn" {
+  value = var.deploy_stac_server ? module.stac-server[0].stac_server_api_lambda_arn : ""
+}
+
+
 output "console_ui_bucket_name" {
   value = var.deploy_console_ui ? module.console-ui[0].console_ui_bucket_name : ""
 }

--- a/profiles/stac-server/outputs.tf
+++ b/profiles/stac-server/outputs.tf
@@ -33,3 +33,19 @@ output "stac_server_lambda_iam_role_arn" {
 output "stac_server_api_gateway_id" {
   value = module.stac-server.stac_server_api_gateway_id
 }
+
+output "stac_server_ingest_lambda_name" {
+  value = module.stac-server.stac_server_ingest_lambda_name
+}
+
+output "stac_server_ingest_lambda_arn" {
+  value = module.stac-server.stac_server_ingest_lambda_arn
+}
+
+output "stac_server_api_lambda_name" {
+  value = module.stac-server.stac_server_api_lambda_name
+}
+
+output "stac_server_api_lambda_arn" {
+  value = module.stac-server.stac_server_api_lambda_arn
+}


### PR DESCRIPTION
## Related issue(s)

- https://github.com/Element84/filmdrop-aws-tf-modules/issues/150

## Proposed Changes

1. Adds `function_name` and `arn` outputs for the stac server ingest and api lambdas

## Testing

This change was validated by the following observations:

1. Ran `./flop test`

## Checklist

- [ ] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary
