### PR TITLE
Update Daskhub Dockerfile to solve packer version errors in Filmdrop Analytics.

### DIFF
--- a/modules/jupyterhub-dask-eks/docker-images/docker_build/daskhub/Dockerfile
+++ b/modules/jupyterhub-dask-eks/docker-images/docker_build/daskhub/Dockerfile
@@ -1,12 +1,53 @@
-FROM pangeo/pangeo-notebook:2022.12.18
+FROM pangeo/pangeo-notebook:2025.06.02
 LABEL maintainer="open-source@element84.com"
 
 USER root
 
-# Install build dependencies
-RUN apt-get update
-RUN apt-get -y install gcc
-RUN pip3 install psycopg2-binary
+# Install system dependencies
+RUN apt-get update && apt-get -y install \
+    gcc \
+    g++ \
+    libgdal-dev \
+    gdal-bin \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install extra dependencies
-RUN pip3 install --no-cache pystac==1.10.0 odc-stac planetary_computer jupyterthemes odc-ui odc-algo
+# The default non-root user in Jupyter Docker Images
+USER jovyan
+
+# Install Python dependencies with proper error handling
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir \
+    # Core STAC and geospatial dependencies
+    pystac==1.10.0 \
+    "pystac-client>=0.7.0" \
+    "odc-stac>=0.3.8" \
+    "planetary_computer>=1.0.0" \
+    # Geospatial core
+    "geopandas>=0.13.0" \
+    "rasterio>=1.3.0" \
+    "shapely>=2.0.0" \
+    "fiona>=1.9.0" \
+    # Data manipulation and analysis
+    "pandas>=2.0.0" \
+    "numpy>=1.24.0" \
+    "xarray>=2023.1.0" \
+    # Visualization
+    "folium>=0.14.0" \
+    "hvplot>=0.8.0" \
+    "matplotlib>=3.6.0" \
+    "plotly>=5.0.0" \
+    # Distributed computing
+    "dask[complete]>=2024.1.0,<2025.0.0" \
+    "dask-gateway>=2023.1.0" \
+    # Jupyter and UI
+    jupyterthemes \
+    ipywidgets \
+    # Database and web
+    psycopg2-binary \
+    "requests>=2.28.0" \
+    # OpenDataCube algorithms
+    odc-ui \
+    odc-algo
+
+# Set working directory
+WORKDIR /home/jovyan/work


### PR DESCRIPTION
This change proposes a new build for Daskhub to enable analytics to be functional in Filmdrop due to package version errors between numpy and pangeo. 

Error:
ValueError                                Traceback (most recent call last)
Cell In[2], line 9
      5 logger.setLevel(logging.INFO)
      7 # ItemMap class for display on a slippy map
----> 9 import folium
...
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject

What was happening?
pangeo/pangeo-notebook:2022.12.18 already contains a Conda stack with a NumPy that was built back in 2022 (NumPy 1.23.x → C-API “size = 88”).

So, when we did pip install without version locking, the dependencies of the packages compiled a newer version of NumPy that mismatches with the NumPy in pangeo-notebook:2022, which caused a C-ABI mismatch.

The fix: Updated daskhub to use one of the newer pangeo-notebook tags 2025.06.02 

Installed other dependencies needed for testing and running playbooks in analytics.

## Related issue(s)

-

## Proposed Changes

1.

## Testing

This change was validated by the following observations:

1.

## Checklist

- [ ] I have deployed and validated this change
- [ ] Changelog
  - [ ] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [ ] README migration
  - [ ] I have added any migration steps to the Readme
  - [ ] No migration is necessary
