### PR TITLE
Adds CIRRUS_DATA_BUCKET to parameter store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added to TF outputs mapping of Cirrus lambda/batch tasks to IAM role arns
 - Added CIRRUS_PAYLOAD_BUCKET as builtin template variable
+- Added CIRRUS_DATA_BUCKET to parameter store
 
 ### Changed
 

--- a/modules/cirrus/param_store.tf
+++ b/modules/cirrus/param_store.tf
@@ -25,6 +25,12 @@ resource "aws_ssm_parameter" "payload_bucket" {
   value = module.base.cirrus_payload_bucket
 }
 
+resource "aws_ssm_parameter" "data_bucket" {
+  name  = "${local.parameter_prefix}CIRRUS_DATA_BUCKET"
+  type  = "String"
+  value = module.base.cirrus_data_bucket
+}
+
 resource "aws_ssm_parameter" "publish_topic_arn" {
   name  = "${local.parameter_prefix}CIRRUS_PUBLISH_TOPIC_ARN"
   type  = "String"


### PR DESCRIPTION
## Related issue(s)

- None

## Proposed Changes

1. Adds CIRRUS_DATA_BUCKET to parameter store. This supports [new CLI commands](https://github.com/cirrus-geo/cirrus-geo/pull/324) in cirrus-geo.

## Testing

This change was validated by the following observations:

1. I used this branch as the filmdrop source for a sandbox filmdrop deployment. The parameter is correctly created in parameter store in the sandbox account.

## Checklist

- [x] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to the changelog
  - [ ] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary
