### PR TITLE
chore: var rename for congruency

### DIFF
--- a/ci.tfvars
+++ b/ci.tfvars
@@ -228,7 +228,7 @@ cirrus_inputs = {
   workflow_definitions_dir                     = null
   workflow_definitions_variables               = null
   workflow_definitions_variables_ssm           = null
-  cirrus_workflow_metrics_enabled              = true
+  workflow_metrics_cloudwatch_enabled          = true
 }
 
 cirrus_dashboard_inputs = {

--- a/default.tfvars
+++ b/default.tfvars
@@ -232,7 +232,7 @@ cirrus_inputs = {
   workflow_definitions_dir                     = null
   workflow_definitions_variables               = null
   workflow_definitions_variables_ssm           = null
-  cirrus_workflow_metrics_enabled              = false
+  workflow_metrics_cloudwatch_enabled          = false
 }
 
 cirrus_dashboard_inputs = {

--- a/inputs.tf
+++ b/inputs.tf
@@ -465,7 +465,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = optional(map(map(string)))
     workflow_definitions_variables_ssm           = optional(map(map(string)))
     cirrus_cli_iam_role_trust_principal          = optional(list(string))
-    cirrus_workflow_metrics_enabled              = optional(bool)
+    workflow_metrics_cloudwatch_enabled          = optional(bool)
   })
   default = {
     data_bucket                               = "cirrus-data-bucket-name"
@@ -522,7 +522,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = null
     workflow_definitions_variables_ssm           = null
     cirrus_cli_iam_role_trust_principal          = null
-    cirrus_workflow_metrics_enabled              = false
+    workflow_metrics_cloudwatch_enabled          = false
   }
 }
 

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -94,9 +94,9 @@ resource "aws_iam_role_policy_attachment" "cirrus_api_lambda_role_policy_attachm
 }
 
 resource "aws_iam_role_policy_attachment" "cirrus_api_lambda_role_policy_attachment3" {
-  count      = var.cirrus_workflow_metrics_enabled ? 1 : 0
+  count      = var.workflow_metrics_cloudwatch_enabled ? 1 : 0
   role       = aws_iam_role.cirrus_api_lambda_role.name
-  policy_arn = var.cirrus_workflow_metrics_read_policy_arn
+  policy_arn = var.workflow_metrics_cloudwatch_read_policy_arn
 }
 
 resource "aws_lambda_function" "cirrus_api" {
@@ -121,8 +121,8 @@ resource "aws_lambda_function" "cirrus_api" {
         CIRRUS_STATE_DB           = var.cirrus_state_dynamodb_table_name
         CIRRUS_EVENT_DB_AND_TABLE = "${var.cirrus_state_event_timestreamwrite_database_name}|${var.cirrus_state_event_timestreamwrite_table_name}"
       },
-      var.cirrus_workflow_metrics_enabled ? {
-        CIRRUS_WORKFLOW_METRIC_NAMESPACE = var.cirrus_workflow_metrics_namespace
+      var.workflow_metrics_cloudwatch_enabled ? {
+        CIRRUS_WORKFLOW_METRIC_NAMESPACE = var.workflow_metrics_cloudwatch_namespace
       } : {}
     )
   }

--- a/modules/cirrus/builtin-functions/inputs.tf
+++ b/modules/cirrus/builtin-functions/inputs.tf
@@ -287,34 +287,34 @@ variable "private_certificate_arn" {
   default     = ""
 }
 
-variable "cirrus_workflow_metrics_enabled" {
+variable "workflow_metrics_cloudwatch_enabled" {
   description = "Whether metrics collection is enabled"
   type        = bool
   nullable    = false
   default     = false
 }
 
-variable "cirrus_workflow_metrics_log_group_name" {
+variable "workflow_metrics_cloudwatch_log_group_name" {
   description = "CloudWatch Log Group name for workflow events"
   type        = string
   nullable    = true
   default     = null
 }
 
-variable "cirrus_workflow_metrics_namespace" {
+variable "workflow_metrics_cloudwatch_namespace" {
   description = "CloudWatch Metrics namespace for workflow metrics"
   type        = string
   nullable    = true
   default     = null
 }
 
-variable "cirrus_workflow_metrics_write_policy_arn" {
+variable "workflow_metrics_cloudwatch_write_policy_arn" {
   description = "ARN of the IAM policy for workflow metrics (only used when metrics are enabled)"
   type        = string
   default     = ""
 }
 
-variable "cirrus_workflow_metrics_read_policy_arn" {
+variable "workflow_metrics_cloudwatch_read_policy_arn" {
   description = "ARN of the IAM policy for workflow metrics (only used when metrics are enabled)"
   type        = string
   default     = ""

--- a/modules/cirrus/builtin-functions/process.tf
+++ b/modules/cirrus/builtin-functions/process.tf
@@ -121,9 +121,9 @@ resource "aws_iam_role_policy_attachment" "cirrus_process_lambda_role_policy_att
 }
 
 resource "aws_iam_role_policy_attachment" "cirrus_process_lambda_role_policy_attachment3" {
-  count      = var.cirrus_workflow_metrics_enabled ? 1 : 0
+  count      = var.workflow_metrics_cloudwatch_enabled ? 1 : 0
   role       = aws_iam_role.cirrus_process_lambda_role.name
-  policy_arn = var.cirrus_workflow_metrics_write_policy_arn
+  policy_arn = var.workflow_metrics_cloudwatch_write_policy_arn
 }
 
 resource "aws_lambda_function" "cirrus_process" {
@@ -151,8 +151,8 @@ resource "aws_lambda_function" "cirrus_process" {
         CIRRUS_WORKFLOW_EVENT_TOPIC_ARN = var.cirrus_workflow_event_sns_topic_arn
         CIRRUS_BASE_WORKFLOW_ARN        = "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
       },
-      var.cirrus_workflow_metrics_enabled ? {
-        CIRRUS_WORKFLOW_LOG_GROUP = var.cirrus_workflow_metrics_log_group_name
+      var.workflow_metrics_cloudwatch_enabled ? {
+        CIRRUS_WORKFLOW_LOG_GROUP = var.workflow_metrics_cloudwatch_log_group_name
       } : {}
     )
   }

--- a/modules/cirrus/builtin-functions/update-state.tf
+++ b/modules/cirrus/builtin-functions/update-state.tf
@@ -96,9 +96,9 @@ resource "aws_iam_role_policy_attachment" "cirrus_update_state_lambda_role_polic
 }
 
 resource "aws_iam_role_policy_attachment" "cirrus_update_state_lambda_role_policy_attachment3" {
-  count      = var.cirrus_workflow_metrics_enabled ? 1 : 0
+  count      = var.workflow_metrics_cloudwatch_enabled ? 1 : 0
   role       = aws_iam_role.cirrus_update_state_lambda_role.name
-  policy_arn = var.cirrus_workflow_metrics_write_policy_arn
+  policy_arn = var.workflow_metrics_cloudwatch_write_policy_arn
 }
 
 resource "aws_lambda_function" "cirrus_update_state" {
@@ -126,8 +126,8 @@ resource "aws_lambda_function" "cirrus_update_state" {
         CIRRUS_PUBLISH_TOPIC_ARN        = var.cirrus_publish_sns_topic_arn
         CIRRUS_PROCESS_QUEUE_URL        = var.cirrus_process_sqs_queue_url
       },
-      var.cirrus_workflow_metrics_enabled ? {
-        CIRRUS_WORKFLOW_LOG_GROUP = var.cirrus_workflow_metrics_log_group_name
+      var.workflow_metrics_cloudwatch_enabled ? {
+        CIRRUS_WORKFLOW_LOG_GROUP = var.workflow_metrics_cloudwatch_log_group_name
       } : {}
     )
   }

--- a/modules/cirrus/builtin_functions.tf
+++ b/modules/cirrus/builtin_functions.tf
@@ -39,11 +39,11 @@ module "builtin_functions" {
   cirrus_process_sqs_queue_arn                     = module.base.cirrus_process_sqs_queue_arn
   cirrus_process_sqs_queue_url                     = module.base.cirrus_process_sqs_queue_url
   cirrus_update_state_dead_letter_sqs_queue_arn    = module.base.cirrus_update_state_dead_letter_sqs_queue_arn
-  cirrus_workflow_metrics_enabled                  = var.cirrus_workflow_metrics_enabled
-  cirrus_workflow_metrics_log_group_name           = var.cirrus_workflow_metrics_enabled ? module.metrics[0].cirrus_workflow_metrics_log_group_name : ""
-  cirrus_workflow_metrics_namespace                = var.cirrus_workflow_metrics_enabled ? module.metrics[0].cirrus_workflow_metrics_namespace : ""
-  cirrus_workflow_metrics_write_policy_arn         = var.cirrus_workflow_metrics_enabled ? module.metrics[0].cirrus_workflow_metrics_write_policy_arn : ""
-  cirrus_workflow_metrics_read_policy_arn          = var.cirrus_workflow_metrics_enabled ? module.metrics[0].cirrus_workflow_metrics_read_policy_arn : ""
+  workflow_metrics_cloudwatch_enabled              = var.workflow_metrics_cloudwatch_enabled
+  workflow_metrics_cloudwatch_log_group_name       = var.workflow_metrics_cloudwatch_enabled ? module.metrics[0].workflow_metrics_cloudwatch_log_group_name : ""
+  workflow_metrics_cloudwatch_namespace            = var.workflow_metrics_cloudwatch_enabled ? module.metrics[0].workflow_metrics_cloudwatch_namespace : ""
+  workflow_metrics_cloudwatch_write_policy_arn     = var.workflow_metrics_cloudwatch_enabled ? module.metrics[0].workflow_metrics_cloudwatch_write_policy_arn : ""
+  workflow_metrics_cloudwatch_read_policy_arn      = var.workflow_metrics_cloudwatch_enabled ? module.metrics[0].workflow_metrics_cloudwatch_read_policy_arn : ""
   warning_sns_topic_arn                            = var.warning_sns_topic_arn
   critical_sns_topic_arn                           = var.critical_sns_topic_arn
   deploy_alarms                                    = var.deploy_alarms

--- a/modules/cirrus/inputs.tf
+++ b/modules/cirrus/inputs.tf
@@ -712,7 +712,7 @@ variable "private_certificate_arn" {
   default     = ""
 }
 
-variable "cirrus_workflow_metrics_enabled" {
+variable "workflow_metrics_cloudwatch_enabled" {
   description = <<-DESCRIPTION
   This enables Cirrus Workflow Metric collection via CloudWatch.  This requires Cirrus version 1.2.0 or greater.  The Workflow Metrics classes replace the EventDB (Timestream-based) system, due to its deprecation.
 

--- a/modules/cirrus/metrics.tf
+++ b/modules/cirrus/metrics.tf
@@ -1,5 +1,5 @@
 module "metrics" {
-  count  = var.cirrus_workflow_metrics_enabled ? 1 : 0
+  count  = var.workflow_metrics_cloudwatch_enabled ? 1 : 0
   source = "./metrics"
 
   resource_prefix = var.resource_prefix

--- a/modules/cirrus/metrics/main.tf
+++ b/modules/cirrus/metrics/main.tf
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_log_metric_filter" "a_workflow_by_event" {
   }
 }
 
-data "aws_iam_policy_document" "cirrus_workflow_metrics_write_policy_doc" {
+data "aws_iam_policy_document" "workflow_metrics_cloudwatch_write_policy_doc" {
   statement {
     actions = [
       "logs:CreateLogStream",
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "cirrus_workflow_metrics_write_policy_doc" {
   }
 }
 
-data "aws_iam_policy_document" "cirrus_workflow_metrics_read_policy_doc" {
+data "aws_iam_policy_document" "workflow_metrics_cloudwatch_read_policy_doc" {
   statement {
     actions = [
       "cloudwatch:GetMetricData",
@@ -62,12 +62,12 @@ data "aws_iam_policy_document" "cirrus_workflow_metrics_read_policy_doc" {
   }
 }
 
-resource "aws_iam_policy" "cirrus_workflow_metrics_write_policy" {
+resource "aws_iam_policy" "workflow_metrics_cloudwatch_write_policy" {
   name   = "${var.resource_prefix}-workflow-metrics-write-policy"
-  policy = data.aws_iam_policy_document.cirrus_workflow_metrics_write_policy_doc.json
+  policy = data.aws_iam_policy_document.workflow_metrics_cloudwatch_write_policy_doc.json
 }
 
-resource "aws_iam_policy" "cirrus_workflow_metrics_read_policy" {
+resource "aws_iam_policy" "workflow_metrics_cloudwatch_read_policy" {
   name   = "${var.resource_prefix}-workflow-metrics-read-policy"
-  policy = data.aws_iam_policy_document.cirrus_workflow_metrics_read_policy_doc.json
+  policy = data.aws_iam_policy_document.workflow_metrics_cloudwatch_read_policy_doc.json
 }

--- a/modules/cirrus/metrics/outputs.tf
+++ b/modules/cirrus/metrics/outputs.tf
@@ -1,19 +1,19 @@
-output "cirrus_workflow_metrics_log_group_name" {
+output "workflow_metrics_cloudwatch_log_group_name" {
   description = "CloudWatch LogGroup for Cirrus Workflow Metrics"
   value       = aws_cloudwatch_log_group.workflow_events.name
 }
 
-output "cirrus_workflow_metrics_namespace" {
+output "workflow_metrics_cloudwatch_namespace" {
   description = "CloudWatch Metrics namespace for Cirrus Workflow Metrics"
   value       = "${var.resource_prefix}-workflow"
 }
 
-output "cirrus_workflow_metrics_write_policy_arn" {
+output "workflow_metrics_cloudwatch_write_policy_arn" {
   description = "ARN of the IAM policy for allowing writes to the Cirrus Workflow Metrics Log Group"
-  value       = aws_iam_policy.cirrus_workflow_metrics_write_policy.arn
+  value       = aws_iam_policy.workflow_metrics_cloudwatch_write_policy.arn
 }
 
-output "cirrus_workflow_metrics_read_policy_arn" {
+output "workflow_metrics_cloudwatch_read_policy_arn" {
   description = "ARN of the IAM policy for allowing reads to the Cirrus Workflow Metrics Namespace"
-  value       = aws_iam_policy.cirrus_workflow_metrics_read_policy.arn
+  value       = aws_iam_policy.workflow_metrics_cloudwatch_read_policy.arn
 }

--- a/profiles/cirrus/inputs.tf
+++ b/profiles/cirrus/inputs.tf
@@ -89,7 +89,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = optional(map(map(string)))
     workflow_definitions_variables_ssm           = optional(map(map(string)))
     cirrus_cli_iam_role_trust_principal          = optional(list(string))
-    cirrus_workflow_metrics_enabled              = optional(bool)
+    workflow_metrics_cloudwatch_enabled          = optional(bool)
   })
   default = {
     data_bucket                               = "cirrus-data-bucket-name"
@@ -147,7 +147,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = null
     workflow_definitions_variables_ssm           = null
     cirrus_cli_iam_role_trust_principal          = null
-    cirrus_workflow_metrics_enabled              = false
+    workflow_metrics_cloudwatch_enabled          = false
   }
 }
 

--- a/profiles/cirrus/main.tf
+++ b/profiles/cirrus/main.tf
@@ -47,7 +47,7 @@ module "cirrus" {
   cirrus_process_sqs_cross_account_sender_arns              = var.cirrus_inputs.process.sqs_cross_account_sender_arns
   private_certificate_arn                                   = var.cirrus_inputs.private_certificate_arn
   domain_alias                                              = var.cirrus_inputs.domain_alias
-  cirrus_workflow_metrics_enabled                           = var.cirrus_inputs.cirrus_workflow_metrics_enabled
+  workflow_metrics_cloudwatch_enabled                       = var.cirrus_inputs.workflow_metrics_cloudwatch_enabled
 }
 
 locals {

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -466,7 +466,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = optional(map(map(string)))
     workflow_definitions_variables_ssm           = optional(map(map(string)))
     cirrus_cli_iam_role_trust_principal          = optional(list(string))
-    cirrus_workflow_metrics_enabled              = optional(bool)
+    workflow_metrics_cloudwatch_enabled          = optional(bool)
   })
   default = {
     data_bucket                               = "cirrus-data-bucket-name"
@@ -523,7 +523,7 @@ variable "cirrus_inputs" {
     workflow_definitions_variables               = null
     workflow_definitions_variables_ssm           = null
     cirrus_cli_iam_role_trust_principal          = null
-    cirrus_workflow_metrics_enabled              = false
+    workflow_metrics_cloudwatch_enabled          = false
   }
 }
 


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- As noted in #199, a var rename for congruency

## Testing

This change was validated by the following observations:

- Running validate and plan, varying the value of workflow_metrics_cloudwatch_enabled, to ensure no breaks in the var chain

## Checklist

- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to the changelog
  - [x] No changelog entry is necessary
- [x] README migration
  - [ ] I have added any migration steps to the Readme
  - [x] No migration is necessary
