### PR TITLE
feat: input opensearch_override_main_response_version

### DIFF
--- a/ci.tfvars
+++ b/ci.tfvars
@@ -44,6 +44,7 @@ stac_server_inputs = {
   opensearch_cluster_dedicated_master_count   = 3
   opensearch_cluster_availability_zone_count  = 3
   opensearch_ebs_volume_size                  = 35
+  opensearch_override_main_response_version   = null
   ingest_sns_topic_arns                       = []
   additional_ingest_sqs_senders_arns          = []
   cors_origin                                 = "*"

--- a/default.tfvars
+++ b/default.tfvars
@@ -45,6 +45,7 @@ stac_server_inputs = {
   opensearch_cluster_dedicated_master_count   = 3
   opensearch_cluster_availability_zone_count  = 3
   opensearch_ebs_volume_size                  = 35
+  opensearch_override_main_response_version   = null
   ingest_sns_topic_arns                       = []
   additional_ingest_sqs_senders_arns          = []
   cors_origin                                 = "*"

--- a/inputs.tf
+++ b/inputs.tf
@@ -99,6 +99,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = number
     opensearch_cluster_availability_zone_count  = number
     opensearch_ebs_volume_size                  = number
+    opensearch_override_main_response_version   = optional(bool)
     ingest_sns_topic_arns                       = list(string)
     additional_ingest_sqs_senders_arns          = list(string)
     cors_origin                                 = string
@@ -183,6 +184,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = 3
     opensearch_cluster_availability_zone_count  = 3
     opensearch_ebs_volume_size                  = 35
+    opensearch_override_main_response_version   = null
     ingest_sns_topic_arns                       = []
     additional_ingest_sqs_senders_arns          = []
     cors_origin                                 = ""

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -99,6 +99,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = number
     opensearch_cluster_availability_zone_count  = number
     opensearch_ebs_volume_size                  = number
+    opensearch_override_main_response_version   = bool
     ingest_sns_topic_arns                       = list(string)
     additional_ingest_sqs_senders_arns          = list(string)
     cors_origin                                 = string
@@ -183,6 +184,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = 3
     opensearch_cluster_availability_zone_count  = 3
     opensearch_ebs_volume_size                  = 35
+    opensearch_override_main_response_version   = null
     ingest_sns_topic_arns                       = []
     additional_ingest_sqs_senders_arns          = []
     cors_origin                                 = "*"

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -62,6 +62,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = number
     opensearch_cluster_availability_zone_count  = number
     opensearch_ebs_volume_size                  = number
+    opensearch_override_main_response_version   = bool
     ingest_sns_topic_arns                       = list(string)
     additional_ingest_sqs_senders_arns          = list(string)
     cors_origin                                 = string
@@ -146,6 +147,7 @@ variable "stac_server_inputs" {
     opensearch_cluster_dedicated_master_count   = 3
     opensearch_cluster_availability_zone_count  = 3
     opensearch_ebs_volume_size                  = 35
+    opensearch_override_main_response_version   = null
     ingest_sns_topic_arns                       = []
     additional_ingest_sqs_senders_arns          = []
     cors_origin                                 = "*"

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -28,6 +28,7 @@ module "stac-server" {
   opensearch_cluster_dedicated_master_count   = var.stac_server_inputs.opensearch_cluster_dedicated_master_count
   opensearch_cluster_availability_zone_count  = var.stac_server_inputs.opensearch_cluster_availability_zone_count
   opensearch_ebs_volume_size                  = var.stac_server_inputs.opensearch_ebs_volume_size
+  opensearch_override_main_response_version   = var.stac_server_inputs.opensearch_override_main_response_version
   ingest_sns_topic_arns                       = var.stac_server_inputs.ingest_sns_topic_arns
   additional_ingest_sqs_senders_arns          = var.stac_server_inputs.additional_ingest_sqs_senders_arns
   api_rest_type                               = var.stac_server_inputs.api_rest_type


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- An optional stac-server var, opensearch_override_main_response_version. See that repo for details on the property

## Testing

This change was validated by the following observations:

- Deploying with this value included and omitted

## Checklist

**General**

- [ ] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
