### PR TITLE
feat: titiler vpce private_dns_enabled

### DIFF
--- a/ci.tfvars
+++ b/ci.tfvars
@@ -96,6 +96,7 @@ titiler_inputs = {
   is_private_endpoint                       = false
   api_method_authorization_type             = "NONE"
   private_certificate_arn                   = ""
+  vpce_private_dns_enabled                  = false
   private_api_additional_security_group_ids = null
   auth_function = {
     cf_function_name             = ""

--- a/default.tfvars
+++ b/default.tfvars
@@ -97,6 +97,7 @@ titiler_inputs = {
   is_private_endpoint                       = false
   api_method_authorization_type             = "NONE"
   private_certificate_arn                   = ""
+  vpce_private_dns_enabled                  = false
   private_api_additional_security_group_ids = null
   auth_function = {
     cf_function_name             = ""

--- a/inputs.tf
+++ b/inputs.tf
@@ -241,6 +241,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = optional(bool)
     api_method_authorization_type             = optional(string)
     private_certificate_arn                   = optional(string)
+    vpce_private_dns_enabled                  = optional(bool)
     private_api_additional_security_group_ids = optional(list(string))
     auth_function = object({
       cf_function_name             = string
@@ -266,6 +267,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = false
     api_method_authorization_type             = "NONE"
     private_certificate_arn                   = ""
+    vpce_private_dns_enabled                  = false
     private_api_additional_security_group_ids = null
     auth_function = {
       cf_function_name             = ""

--- a/modules/mosaic-titiler/inputs.tf
+++ b/modules/mosaic-titiler/inputs.tf
@@ -200,3 +200,14 @@ variable "private_certificate_arn" {
   type        = string
   default     = ""
 }
+
+variable "vpce_private_dns_enabled" {
+  type        = bool
+  default     = false
+  description = <<-DESCRIPTION
+  Whether to enable Private DNS on the Interface VPC Endpoint used for the STAC API (execute-api). 
+  Only applicable when is_private_endpoint is true, otherwise ignored.
+  Leave false if you rely on VPC endpoint-specific hostnames; set true to resolve the standard API Gateway 
+  hostname to the VPC endpoint from within the VPC.
+  DESCRIPTION
+}

--- a/modules/mosaic-titiler/titler-mosaicjson-private-api.tf
+++ b/modules/mosaic-titiler/titler-mosaicjson-private-api.tf
@@ -26,14 +26,13 @@ resource "aws_vpc_security_group_ingress_rule" "titiler_api_gateway_private_vcpe
 resource "aws_vpc_endpoint" "titiler_api_gateway_private" {
   count = var.is_private_endpoint ? 1 : 0
 
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.execute-api"
-  vpc_id            = var.vpc_id
-  vpc_endpoint_type = "Interface"
-  ip_address_type   = "ipv4"
-  subnet_ids        = data.aws_subnet.selected[*].id
-  auto_accept       = true
-  # required to enable private dns for this vpc endpoint/the titiler api gateway private endpoint
-  private_dns_enabled = true
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  vpc_id              = var.vpc_id
+  vpc_endpoint_type   = "Interface"
+  ip_address_type     = "ipv4"
+  subnet_ids          = data.aws_subnet.selected[*].id
+  auto_accept         = true
+  private_dns_enabled = var.vpce_private_dns_enabled
   security_group_ids = concat(
     aws_security_group.titiler_api_gateway_private_vpce[*].id,
     coalesce(var.private_api_additional_security_group_ids, [])

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -241,6 +241,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = optional(bool)
     api_method_authorization_type             = optional(string)
     private_certificate_arn                   = optional(string)
+    vpce_private_dns_enabled                  = optional(bool)
     private_api_additional_security_group_ids = optional(list(string))
     auth_function = object({
       cf_function_name             = string
@@ -266,6 +267,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = false
     api_method_authorization_type             = "NONE"
     private_certificate_arn                   = ""
+    vpce_private_dns_enabled                  = false
     private_api_additional_security_group_ids = null
     auth_function = {
       cf_function_name             = ""

--- a/profiles/titiler/inputs.tf
+++ b/profiles/titiler/inputs.tf
@@ -36,6 +36,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = optional(bool)
     api_method_authorization_type             = optional(string)
     private_certificate_arn                   = optional(string)
+    vpce_private_dns_enabled                  = optional(bool)
     private_api_additional_security_group_ids = optional(list(string))
     auth_function = object({
       cf_function_name             = string
@@ -61,6 +62,7 @@ variable "titiler_inputs" {
     is_private_endpoint                       = false
     api_method_authorization_type             = "NONE"
     private_certificate_arn                   = ""
+    vpce_private_dns_enabled                  = false
     private_api_additional_security_group_ids = null
     auth_function = {
       cf_function_name             = ""

--- a/profiles/titiler/main.tf
+++ b/profiles/titiler/main.tf
@@ -20,6 +20,7 @@ module "titiler" {
   is_private_endpoint                       = var.titiler_inputs.is_private_endpoint
   domain_alias                              = var.titiler_inputs.domain_alias
   private_certificate_arn                   = var.titiler_inputs.private_certificate_arn
+  vpce_private_dns_enabled                  = var.titiler_inputs.vpce_private_dns_enabled
 }
 
 module "cloudfront_api_gateway_endpoint" {


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- Allows setting `private_dns_enabled` via a var, for titiler's vpc endpoint (only applicable with private type api gateway)

## Testing

This change was validated by the following observations:

- Deploying with the var left undefined, true, and false

## Checklist

**General**

- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
