### PR TITLE
feat: stac server api gateway custom vpce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- A new stac_server_inputs.custom_vpce_id var added. If provided, the user is indicating that they have an existing vpc endpoint that the stac server api gateway (and supporting resources) should allow to ingress
+
 - A new titiler_inputs.custom_vpce_id var added. If provided, the user is indicating that they have an existing vpc endpoint that the titiler api gateway (and supporting resources) should allow to ingress
 
 ### Changed

--- a/ci.tfvars
+++ b/ci.tfvars
@@ -58,6 +58,7 @@ stac_server_inputs = {
   pre_hook_lambda                             = null
   private_certificate_arn                     = ""
   vpce_private_dns_enabled                    = false
+  custom_vpce_id                              = null
   auth_function = {
     cf_function_name             = ""
     cf_function_runtime          = "cloudfront-js-2.0"

--- a/default.tfvars
+++ b/default.tfvars
@@ -59,6 +59,7 @@ stac_server_inputs = {
   pre_hook_lambda                             = null
   private_certificate_arn                     = ""
   vpce_private_dns_enabled                    = false
+  custom_vpce_id                              = null
   auth_function = {
     cf_function_name             = ""
     cf_function_runtime          = "cloudfront-js-2.0"

--- a/inputs.tf
+++ b/inputs.tf
@@ -112,6 +112,7 @@ variable "stac_server_inputs" {
     private_api_additional_security_group_ids   = optional(list(string))
     private_certificate_arn                     = optional(string)
     vpce_private_dns_enabled                    = bool
+    custom_vpce_id                              = optional(string)
     api_lambda = optional(object({
       handler               = optional(string)
       memory_mb             = optional(number)
@@ -200,6 +201,7 @@ variable "stac_server_inputs" {
     pre_hook_lambda                             = null
     private_certificate_arn                     = ""
     vpce_private_dns_enabled                    = false
+    custom_vpce_id                              = null
     auth_function = {
       cf_function_name             = ""
       cf_function_runtime          = "cloudfront-js-2.0"

--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -112,6 +112,7 @@ variable "stac_server_inputs" {
     private_api_additional_security_group_ids   = optional(list(string))
     private_certificate_arn                     = optional(string)
     vpce_private_dns_enabled                    = bool
+    custom_vpce_id                              = optional(string)
     api_lambda = optional(object({
       handler               = optional(string)
       memory_mb             = optional(number)
@@ -200,6 +201,7 @@ variable "stac_server_inputs" {
     pre_hook_lambda                             = null
     private_certificate_arn                     = ""
     vpce_private_dns_enabled                    = false
+    custom_vpce_id                              = null
     auth_function = {
       cf_function_name             = ""
       cf_function_runtime          = "cloudfront-js-2.0"

--- a/profiles/stac-server/inputs.tf
+++ b/profiles/stac-server/inputs.tf
@@ -75,6 +75,7 @@ variable "stac_server_inputs" {
     private_api_additional_security_group_ids   = optional(list(string))
     private_certificate_arn                     = optional(string)
     vpce_private_dns_enabled                    = bool
+    custom_vpce_id                              = optional(string)
     api_lambda = optional(object({
       handler               = optional(string)
       memory_mb             = optional(number)
@@ -163,6 +164,7 @@ variable "stac_server_inputs" {
     pre_hook_lambda                             = null
     private_certificate_arn                     = ""
     vpce_private_dns_enabled                    = false
+    custom_vpce_id                              = null
     auth_function = {
       cf_function_name             = ""
       cf_function_runtime          = "cloudfront-js-2.0"

--- a/profiles/stac-server/main.tf
+++ b/profiles/stac-server/main.tf
@@ -43,6 +43,7 @@ module "stac-server" {
   deploy_stac_server_outside_vpc              = var.deploy_stac_server_outside_vpc
   private_certificate_arn                     = var.stac_server_inputs.private_certificate_arn
   vpce_private_dns_enabled                    = var.stac_server_inputs.vpce_private_dns_enabled
+  custom_vpce_id                              = var.stac_server_inputs.custom_vpce_id
   domain_alias                                = var.stac_server_inputs.domain_alias
 
   # CloudFront or a custom domain implies the rootpath is simply "/"


### PR DESCRIPTION
## Related issue(s)

- NA

## Proposed Changes

- A new, optional var `custom_vpce_id`. If provided, the user is indicating that they have an existing vpc endpoint that the stac server api gateway (and supporting resources) should allow to ingress

## Testing

This change was validated by the following observations:

- Deployment tests with this var set, undefined, and null

## Checklist

**General**

- [x] I have deployed and validated this change
- [x] Changelog
  - [x] I have added my changes to CHANGELOG.md
  - [ ] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
