### PR TITLE
chore: replaced deprecated aws_region property

### DIFF
--- a/modules/base_infra/api_gateway_account/api_gateway_account.tf
+++ b/modules/base_infra/api_gateway_account/api_gateway_account.tf
@@ -4,7 +4,7 @@ locals {
 
 
 resource "aws_iam_role" "shared_api_gw_logging_role" {
-  name_prefix = "${local.name_prefix}-${data.aws_region.current.name}-apigw-"
+  name_prefix = "${local.name_prefix}-${data.aws_region.current.region}-apigw-"
 
   assume_role_policy = <<-JSON_POLICY_STRING
   {
@@ -23,7 +23,7 @@ resource "aws_iam_role" "shared_api_gw_logging_role" {
 }
 
 resource "aws_iam_policy" "shared_api_gw_logging_role" {
-  name_prefix = "${local.name_prefix}-${data.aws_region.current.name}-apigw-log-policy-"
+  name_prefix = "${local.name_prefix}-${data.aws_region.current.region}-apigw-log-policy-"
 
   policy = <<-JSON_POLICY_STRING
   {

--- a/modules/base_infra/log_archive/s3_access_logs.tf
+++ b/modules/base_infra/log_archive/s3_access_logs.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_public_access_block" "s3_access_logs_bucket_public_acces
 resource "null_resource" "cleanup_s3_access_logs_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.s3_access_logs_bucket.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/base_infra/log_archive/s3_logs_archive.tf
+++ b/modules/base_infra/log_archive/s3_logs_archive.tf
@@ -255,7 +255,7 @@ resource "aws_s3_bucket_public_access_block" "s3_logs_archive_bucket_public_acce
 resource "null_resource" "cleanup_s3_logs_archive_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.s3_logs_archive_bucket.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/base_infra/vpc_infra/vpc_endpoints.tf
+++ b/modules/base_infra/vpc_infra/vpc_endpoints.tf
@@ -4,7 +4,7 @@ module "gateway_endpoints" {
   for_each = toset(var.gateway_endpoints_list)
 
   vpc_id          = aws_vpc.filmdrop_vpc.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.${each.value}"
   route_table_ids = concat([aws_route_table.public_route_table.id], values(aws_route_table.private_route_tables)[*].id)
 }
 
@@ -14,7 +14,7 @@ module "interface_endpoints" {
   for_each = toset(var.interface_endpoints_list)
 
   vpc_id              = aws_vpc.filmdrop_vpc.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.${each.value}"
   security_group_ids  = [aws_security_group.filmdrop_vpc_default_sg.id]
   subnet_ids          = values(aws_subnet.private_subnets)[*].id
   private_dns_enabled = true

--- a/modules/base_infra/vpc_infra/vpc_subnets.tf
+++ b/modules/base_infra/vpc_infra/vpc_subnets.tf
@@ -36,7 +36,7 @@ resource "aws_subnet" "private_subnets" {
 # Set up default DHCP options for DNS resolution in FilmDrop VPC - defaults to AmazonProvidedDNS
 resource "aws_vpc_dhcp_options" "vpc_dhcp_options" {
   domain_name_servers = var.dhcp_options_domain_name_servers
-  domain_name         = "${data.aws_region.current.name}.compute.internal"
+  domain_name         = "${data.aws_region.current.region}.compute.internal"
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {

--- a/modules/cirrus-dashboard/cirrus_dashboard.tf
+++ b/modules/cirrus-dashboard/cirrus_dashboard.tf
@@ -18,7 +18,7 @@ resource "aws_codebuild_project" "cirrus_dashboard_codebuild" {
 
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
-      value = data.aws_region.current.name
+      value = data.aws_region.current.region
     }
 
     environment_variable {
@@ -74,7 +74,7 @@ resource "aws_codebuild_project" "cirrus_dashboard_codebuild" {
 resource "null_resource" "trigger_cirrus_dashboard_upgrade" {
   triggers = {
     new_codebuild                = aws_codebuild_project.cirrus_dashboard_codebuild.id
-    region                       = data.aws_region.current.name
+    region                       = data.aws_region.current.region
     account                      = data.aws_caller_identity.current.account_id
     cirrus_dashboard_release_tag = var.cirrus_dashboard_release_tag
     cirrus_api_endpoint          = var.cirrus_api_endpoint
@@ -88,8 +88,8 @@ resource "null_resource" "trigger_cirrus_dashboard_upgrade" {
   provisioner "local-exec" {
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Triggering CodeBuild Project."
 aws codebuild start-build --project-name ${aws_codebuild_project.cirrus_dashboard_codebuild.id}
@@ -146,7 +146,7 @@ resource "aws_s3_object" "cirrus_dashboard_build_spec" {
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.cirrus_dashboard_source_config.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/cirrus/builtin-functions/api.tf
+++ b/modules/cirrus/builtin-functions/api.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "cirrus_api_lambda_policy_main_doc" {
       "secretsmanager:GetSecretValue"
     ]
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.resource_prefix}*"
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${var.resource_prefix}*"
     ]
   }
 
@@ -182,7 +182,7 @@ resource "aws_vpc_security_group_ingress_rule" "cirrus_api_gateway_private_vpce"
 resource "aws_vpc_endpoint" "cirrus_api_gateway_private" {
   count = local.is_private_endpoint ? 1 : 0
 
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "cirrus_api_gateway_private" {
     sid       = "DenyApiInvokeForNonVpceTraffic"
     effect    = "Deny"
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*"]
 
     principals {
       type        = "AWS"
@@ -233,7 +233,7 @@ data "aws_iam_policy_document" "cirrus_api_gateway_private" {
     sid       = "AllowApiInvoke"
     effect    = "Allow"
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*"]
 
     principals {
       type        = "AWS"
@@ -261,7 +261,7 @@ resource "aws_api_gateway_integration" "cirrus_api_gateway_root_method_integrati
   resource_id             = aws_api_gateway_rest_api.cirrus_api_gateway.root_resource_id
   http_method             = aws_api_gateway_method.cirrus_api_gateway_root_method.http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.cirrus_api.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.cirrus_api.arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -283,7 +283,7 @@ resource "aws_api_gateway_integration" "cirrus_api_gateway_proxy_resource_method
   resource_id             = aws_api_gateway_resource.cirrus_api_gateway_proxy_resource.id
   http_method             = aws_api_gateway_method.cirrus_api_gateway_proxy_resource_method.http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.cirrus_api.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.cirrus_api.arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -324,7 +324,7 @@ resource "aws_lambda_permission" "cirrus_api_gateway_lambda_permission_root_reso
   function_name = aws_lambda_function.cirrus_api.arn
   principal     = "apigateway.amazonaws.com"
 
-  source_arn = "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*/*"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*/*"
 }
 
 resource "aws_lambda_permission" "cirrus_api_gateway_lambda_permission_proxy_resource" {
@@ -333,7 +333,7 @@ resource "aws_lambda_permission" "cirrus_api_gateway_lambda_permission_proxy_res
   function_name = aws_lambda_function.cirrus_api.arn
   principal     = "apigateway.amazonaws.com"
 
-  source_arn = "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*/*${aws_api_gateway_resource.cirrus_api_gateway_proxy_resource.path}"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.cirrus_api_gateway.id}/*/*${aws_api_gateway_resource.cirrus_api_gateway_proxy_resource.path}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cirrus_api_lambda_errors_warning_alarm" {
@@ -437,13 +437,13 @@ resource "aws_api_gateway_domain_name" "cirrus_api_gateway_domain_name" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/domainnames/*"
+      "Resource": "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/domainnames/*"
     },
     {
       "Effect": "Deny",
       "Principal": "*",
       "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/domainnames/*",
+      "Resource": "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/domainnames/*",
       "Condition": {
         "StringNotEquals": {
           "aws:SourceVpce": "${aws_vpc_endpoint.cirrus_api_gateway_private[0].id}"

--- a/modules/cirrus/builtin-functions/data.tf
+++ b/modules/cirrus/builtin-functions/data.tf
@@ -10,5 +10,5 @@ data "aws_subnet" "selected" {
 locals {
   # Save as locals to avoid obnoxiously long lines
   current_account = data.aws_caller_identity.current.account_id
-  current_region  = data.aws_region.current.name
+  current_region  = data.aws_region.current.region
 }

--- a/modules/cirrus/builtin-functions/process.tf
+++ b/modules/cirrus/builtin-functions/process.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "cirrus_process_lambda_policy_main_doc" {
       "secretsmanager:GetSecretValue"
     ]
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.resource_prefix}*"
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${var.resource_prefix}*"
     ]
   }
 
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "cirrus_process_lambda_policy_main_doc" {
       "states:StartExecution"
     ]
     resources = [
-      "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-*"
+      "arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-*"
     ]
   }
 
@@ -179,7 +179,7 @@ resource "aws_lambda_function" "cirrus_process" {
         CIRRUS_PAYLOAD_BUCKET           = var.cirrus_payload_bucket
         CIRRUS_STATE_DB                 = var.cirrus_state_dynamodb_table_name
         CIRRUS_WORKFLOW_EVENT_TOPIC_ARN = var.cirrus_workflow_event_sns_topic_arn
-        CIRRUS_BASE_WORKFLOW_ARN        = "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
+        CIRRUS_BASE_WORKFLOW_ARN        = "arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
       },
       var.workflow_metrics_timestream_enabled ? {
         CIRRUS_EVENT_DB_AND_TABLE = "${var.cirrus_state_event_timestreamwrite_database_name}|${var.cirrus_state_event_timestreamwrite_table_name}"

--- a/modules/cirrus/builtin-functions/update-state.tf
+++ b/modules/cirrus/builtin-functions/update-state.tf
@@ -180,7 +180,7 @@ resource "aws_cloudwatch_event_rule" "cirrus_update_state_rule" {
   "detail": {
     "stateMachineArn": [
       {
-        "prefix": "arn:aws:states:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
+        "prefix": "arn:aws:states:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.resource_prefix}-"
       }
     ],
     "status": [

--- a/modules/cirrus/data.tf
+++ b/modules/cirrus/data.tf
@@ -4,5 +4,5 @@ data "aws_region" "current" {}
 locals {
   # Save as locals to avoid obnoxiously long lines
   current_account = data.aws_caller_identity.current.account_id
-  current_region  = data.aws_region.current.name
+  current_region  = data.aws_region.current.region
 }

--- a/modules/cirrus/task-batch-compute/main.tf
+++ b/modules/cirrus/task-batch-compute/main.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 locals {
   # Save as locals to avoid obnoxiously long lines
   current_account = data.aws_caller_identity.current.account_id
-  current_region  = data.aws_region.current.name
+  current_region  = data.aws_region.current.region
 
   # Only create if an existing compute environment config was not provided
   create_compute_environment = (

--- a/modules/cirrus/task/data.tf
+++ b/modules/cirrus/task/data.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 locals {
   # Save as locals to avoid obnoxiously long lines
   current_account = data.aws_caller_identity.current.account_id
-  current_region  = data.aws_region.current.name
+  current_region  = data.aws_region.current.region
 
   # For determining whether a task image is in ECR.
   # Used in conjunction with `resolve_ecr_tag_to_digest`.

--- a/modules/cirrus/workflow/main.tf
+++ b/modules/cirrus/workflow/main.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 locals {
   # Save as locals to avoid obnoxiously long lines
   current_account = data.aws_caller_identity.current.account_id
-  current_region  = data.aws_region.current.name
+  current_region  = data.aws_region.current.region
 
   # Create the workflow's state machine JSON.
   # Use the Cirrus task output map, user-defined template variable map, and

--- a/modules/cloudfront/content/content_bucket.tf
+++ b/modules/cloudfront/content/content_bucket.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket_versioning" "content_bucket_versioning" {
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.content_bucket.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/cloudfront/custom_origin/custom_origin.tf
+++ b/modules/cloudfront/custom_origin/custom_origin.tf
@@ -13,8 +13,8 @@ resource "null_resource" "wait_ssl_issued" {
     # check that the cert is ready
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 COUNT=0
 STATUS=""
@@ -79,7 +79,7 @@ resource "aws_cloudfront_distribution" "filmdrop_managed_cloudfront_distribution
   logging_config {
     include_cookies = var.log_cookies
     bucket          = var.create_log_bucket ? aws_s3_bucket.log_bucket[0].bucket_domain_name : var.log_bucket_domain_name
-    prefix          = "cloudfront/AWSLogs/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.name}/${var.environment}/${var.project_name}/${var.application_name}"
+    prefix          = "cloudfront/AWSLogs/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.region}/${var.environment}/${var.project_name}/${var.application_name}"
   }
 
   aliases = var.domain_aliases

--- a/modules/cloudfront/custom_origin/headers.tf
+++ b/modules/cloudfront/custom_origin/headers.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "cloudfront_headers_lambda" {
       FORWARDEDPROTO           = "https"
       AUTHKEYNAME              = var.auth_header_name
       AUTHKEYVALUE             = var.auth_header_value
-      REGION                   = data.aws_region.current.name
+      REGION                   = data.aws_region.current.region
       SSM_FORWARDED_HOST_PARAM = aws_ssm_parameter.cloudfront_x_forwarded_host.name
     }
   }
@@ -30,8 +30,8 @@ resource "null_resource" "update_cloudfront_headers" {
   provisioner "local-exec" {
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Update CloudFront Headers."
 aws lambda invoke --function-name ${aws_lambda_function.cloudfront_headers_lambda.function_name} --payload '{ }' output

--- a/modules/cloudfront/custom_origin/logging.tf
+++ b/modules/cloudfront/custom_origin/logging.tf
@@ -124,7 +124,7 @@ resource "null_resource" "cleanup_bucket" {
 
   triggers = {
     bucket_name = aws_s3_bucket.log_bucket[0].id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/cloudfront/s3_origin/logging.tf
+++ b/modules/cloudfront/s3_origin/logging.tf
@@ -123,7 +123,7 @@ resource "null_resource" "cleanup_bucket" {
 
   triggers = {
     bucket_name = aws_s3_bucket.log_bucket[0].id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/cloudfront/s3_origin/s3_origin.tf
+++ b/modules/cloudfront/s3_origin/s3_origin.tf
@@ -13,8 +13,8 @@ resource "null_resource" "wait_ssl_issued" {
     # check that the cert is ready
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 COUNT=0
 STATUS=""
@@ -53,7 +53,7 @@ resource "aws_cloudfront_distribution" "filmdrop_managed_cloudfront_distribution
   logging_config {
     include_cookies = var.log_cookies
     bucket          = var.create_log_bucket ? aws_s3_bucket.log_bucket[0].bucket_domain_name : var.log_bucket_domain_name
-    prefix          = "cloudfront/AWSLogs/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.name}/${var.environment}/${var.project_name}/${var.application_name}"
+    prefix          = "cloudfront/AWSLogs/${data.aws_caller_identity.current.account_id}/${data.aws_region.current.region}/${var.environment}/${var.project_name}/${var.application_name}"
   }
 
   aliases = var.domain_aliases

--- a/modules/console-ui/console_ui.tf
+++ b/modules/console-ui/console_ui.tf
@@ -18,7 +18,7 @@ resource "aws_codebuild_project" "console_ui_codebuild" {
 
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
-      value = data.aws_region.current.name
+      value = data.aws_region.current.region
     }
 
     environment_variable {
@@ -79,7 +79,7 @@ resource "aws_codebuild_project" "console_ui_codebuild" {
 resource "null_resource" "trigger_console_ui_upgrade" {
   triggers = {
     new_codebuild           = aws_codebuild_project.console_ui_codebuild.id
-    region                  = data.aws_region.current.name
+    region                  = data.aws_region.current.region
     account                 = data.aws_caller_identity.current.account_id
     filmdrop_ui_release_tag = var.filmdrop_ui_release_tag
     filmdrop_ui_config      = var.filmdrop_ui_config
@@ -91,8 +91,8 @@ resource "null_resource" "trigger_console_ui_upgrade" {
   provisioner "local-exec" {
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Triggering CodeBuild Project."
 START_RESULT=$(aws codebuild start-build --project-name ${aws_codebuild_project.console_ui_codebuild.id})
@@ -167,7 +167,7 @@ resource "aws_s3_object" "console_ui_build_spec" {
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.console_ui_source_config.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/eks/modules/karpenter/data.tf
+++ b/modules/eks/modules/karpenter/data.tf
@@ -389,7 +389,7 @@ data "aws_iam_policy_document" "node_assume_role" {
 locals {
   account_id             = data.aws_caller_identity.current.account_id
   partition              = data.aws_partition.current.partition
-  region                 = data.aws_region.current.name
+  region                 = data.aws_region.current.region
   create_iam_role        = var.create && var.create_iam_role
   irsa_oidc_provider_url = replace(var.irsa_oidc_provider_arn, "/^(.*provider/)/", "")
   events = {

--- a/modules/jupyterhub-dask-eks/cleanup/main.tf
+++ b/modules/jupyterhub-dask-eks/cleanup/main.tf
@@ -114,8 +114,8 @@ resource "null_resource" "analytics_cleanup_lambda" {
   provisioner "local-exec" {
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Running FilmDrop Analytics Cleanup Lambda."
 aws lambda invoke --function-name ${aws_lambda_function.analytics_cleanup_lambda.function_name} --payload '{ }' output

--- a/modules/jupyterhub-dask-eks/docker-images/docker-images.tf
+++ b/modules/jupyterhub-dask-eks/docker-images/docker-images.tf
@@ -75,7 +75,7 @@ resource "aws_codebuild_project" "daskhub_docker_image" {
 
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
-      value = data.aws_region.current.name
+      value = data.aws_region.current.region
     }
 
     environment_variable {
@@ -129,8 +129,8 @@ resource "null_resource" "trigger_codebuild" {
   provisioner "local-exec" {
     interpreter = ["bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Triggering CodeBuild Project."
 START_RESULT=$(aws codebuild start-build --project-name ${aws_codebuild_project.daskhub_docker_image.id})
@@ -168,7 +168,7 @@ EOF
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.docker_image_build_source.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/jupyterhub-dask-eks/docker-images/iam.tf
+++ b/modules/jupyterhub-dask-eks/docker-images/iam.tf
@@ -48,8 +48,8 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/daskhub_image_build",
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/daskhub_image_build:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/daskhub_image_build",
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/daskhub_image_build:*"
       ],
       "Action": [
         "logs:CreateLogGroup",
@@ -60,8 +60,8 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/daskhub-docker-image",
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/daskhub-docker-image:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/daskhub-docker-image",
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/daskhub-docker-image:*"
       ],
       "Action": [
         "logs:CreateLogGroup",
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::codepipeline-${data.aws_region.current.name}-*"
+        "arn:aws:s3:::codepipeline-${data.aws_region.current.region}-*"
       ],
       "Action": [
         "s3:PutObject",
@@ -91,7 +91,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
         "codebuild:BatchPutTestCases"
       ],
       "Resource": [
-        "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:report-group/daskhub-docker-image-*"
+        "arn:aws:codebuild:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:report-group/daskhub-docker-image-*"
       ]
     },
     {
@@ -110,7 +110,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Action": "ec2:CreateNetworkInterfacePermission",
-      "Resource": "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+      "Resource": "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
     },
     {
       "Effect": "Allow",

--- a/modules/mosaic-titiler/outputs.tf
+++ b/modules/mosaic-titiler/outputs.tf
@@ -3,7 +3,7 @@ output "titiler_mosaic_api_gateway_id" {
 }
 
 output "titiler_mosaic_api_gateway_endpoint" {
-  value = var.is_private_endpoint ? "${aws_api_gateway_rest_api.titiler_api_gateway[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com" : "${aws_apigatewayv2_api.titiler-mosaic-api-gateway[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com"
+  value = var.is_private_endpoint ? "${aws_api_gateway_rest_api.titiler_api_gateway[0].id}.execute-api.${data.aws_region.current.region}.amazonaws.com" : "${aws_apigatewayv2_api.titiler-mosaic-api-gateway[0].id}.execute-api.${data.aws_region.current.region}.amazonaws.com"
 }
 
 output "titiler_mosaic_wafv2_web_acl_arn" {

--- a/modules/mosaic-titiler/titler-mosaicjson-private-api.tf
+++ b/modules/mosaic-titiler/titler-mosaicjson-private-api.tf
@@ -33,7 +33,7 @@ resource "aws_vpc_security_group_ingress_rule" "titiler_api_gateway_private_vcpe
 resource "aws_vpc_endpoint" "titiler_api_gateway_private" {
   count = local.create_vpce ? 1 : 0
 
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   vpc_id              = var.vpc_id
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "titiler_api_gateway_private" {
     sid       = "DenyApiInvokeForNonVpceTraffic"
     effect    = "Deny"
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*"]
 
     principals {
       type        = "AWS"
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "titiler_api_gateway_private" {
     sid       = "AllowApiInvoke"
     effect    = "Allow"
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*"]
 
     principals {
       type        = "AWS"
@@ -120,7 +120,7 @@ resource "aws_api_gateway_integration" "titiler_api_gateway_root_method_integrat
   resource_id             = aws_api_gateway_rest_api.titiler_api_gateway[0].root_resource_id
   http_method             = aws_api_gateway_method.titiler_api_gateway_root_method[0].http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.titiler-mosaic-lambda.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.titiler-mosaic-lambda.arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -229,7 +229,7 @@ resource "aws_api_gateway_integration" "titiler_api_gateway_proxy_resource_metho
   resource_id             = aws_api_gateway_resource.titiler_api_gateway_proxy_resource[0].id
   http_method             = aws_api_gateway_method.titiler_api_gateway_proxy_resource_method[0].http_method
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_function.titiler-mosaic-lambda.arn}/invocations"
+  uri                     = "arn:aws:apigateway:${data.aws_region.current.region}:lambda:path/2015-03-31/functions/${aws_lambda_function.titiler-mosaic-lambda.arn}/invocations"
   integration_http_method = "POST"
 }
 
@@ -275,7 +275,7 @@ resource "aws_lambda_permission" "titiler_api_gateway_lambda_permission_root_res
   function_name = aws_lambda_function.titiler-mosaic-lambda.arn
   principal     = "apigateway.amazonaws.com"
 
-  source_arn = "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*/*"
+  source_arn = "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.titiler_api_gateway[0].id}/*/*"
 }
 
 resource "aws_api_gateway_domain_name" "titiler_api_gateway_domain_name" {
@@ -295,13 +295,13 @@ resource "aws_api_gateway_domain_name" "titiler_api_gateway_domain_name" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/domainnames/*"
+      "Resource": "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/domainnames/*"
     },
     {
       "Effect": "Deny",
       "Principal": "*",
       "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/domainnames/*",
+      "Resource": "arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:/domainnames/*",
       "Condition": {
         "StringNotEquals": {
           "aws:SourceVpce": "${local.vpce_id}"

--- a/modules/mosaic-titiler/titler-mosaicjson.tf
+++ b/modules/mosaic-titiler/titler-mosaicjson.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "titiler-mosaic-lambda" {
       AWS_REQUEST_PAYER                  = var.aws_request_payer
       GDAL_INGESTED_BYTES_AT_OPEN        = var.gdal_ingested_bytes_at_open
       MOSAIC_BACKEND                     = "dynamodb://"
-      MOSAIC_HOST                        = "${data.aws_region.current.name}/${aws_dynamodb_table.titiler-mosaic-dynamodb-table.name}"
+      MOSAIC_HOST                        = "${data.aws_region.current.region}/${aws_dynamodb_table.titiler-mosaic-dynamodb-table.name}"
       REQUEST_HOST_HEADER_OVERRIDE       = var.request_host_header_override
       MOSAIC_TILE_TIMEOUT                = var.mosaic_tile_timeout
     }
@@ -384,7 +384,7 @@ resource "aws_wafv2_web_acl" "titiler-mosaic-wafv2-web-acl" {
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.lambda-source.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/ssm_bastion/iam.tf
+++ b/modules/ssm_bastion/iam.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role_policy_attachment" "AmazonS3ReadOnlyAccess" {
 
 resource "aws_iam_role_policy_attachment" "AcceleratorSSMPolicy" {
   count      = var.attach_accelerator_policy == true ? 1 : 0
-  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/AWSAccelerator-SessionManagerUserKMS-${data.aws_region.current.name}"
+  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/AWSAccelerator-SessionManagerUserKMS-${data.aws_region.current.region}"
   role       = aws_iam_role.ssm_bastion_role.name
 }
 

--- a/modules/ssm_bastion/kms.tf
+++ b/modules/ssm_bastion/kms.tf
@@ -68,7 +68,7 @@ resource "aws_s3_bucket_policy" "filmdrop_public_keys_bucket_policy" {
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.filmdrop_public_keys_bucket.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/ssm_bastion/main.tf
+++ b/modules/ssm_bastion/main.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "ssm_bastion" {
     "${path.module}/user_data.tpl",
     {
       PublicKeysBucket = aws_s3_bucket.filmdrop_public_keys_bucket.id
-      AWSRegion        = data.aws_region.current.name
+      AWSRegion        = data.aws_region.current.region
     },
   )
   key_name = var.key_name

--- a/modules/stac-server/api_auth.tf
+++ b/modules/stac-server/api_auth.tf
@@ -49,7 +49,7 @@ resource "null_resource" "cleanup_stac_server_api_auth_keys" {
 
   triggers = {
     stac_server_api_auth_keys = "${local.name_prefix}-stac-server-api-auth-keys"
-    region                    = data.aws_region.current.name
+    region                    = data.aws_region.current.region
     account                   = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/stac-server/iam.tf
+++ b/modules/stac-server/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "stac_api_lambda_role" {
-  name_prefix = "${local.name_prefix}-stac-server-${data.aws_region.current.name}"
+  name_prefix = "${local.name_prefix}-stac-server-${data.aws_region.current.region}"
 
   assume_role_policy = <<EOF
 {
@@ -25,17 +25,17 @@ locals {
         "logs:CreateLogStream",
         "logs:CreateLogGroup",
       ]
-      Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.name_prefix}-stac-server*:*"
+      Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.name_prefix}-stac-server*:*"
       Effect   = "Allow"
       },
       {
         Action   = ["logs:PutLogEvents"]
-        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.name_prefix}-stac-server-*:*:*"
+        Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.name_prefix}-stac-server-*:*:*"
         Effect   = "Allow"
       },
       {
         Action   = ["es:*"]
-        Resource = "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/*"
+        Resource = "arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/*"
         Effect   = "Allow"
       },
       {
@@ -92,7 +92,7 @@ locals {
 }
 
 resource "aws_iam_policy" "stac_api_lambda_policy" {
-  name_prefix = "${local.name_prefix}-stac-server-${data.aws_region.current.name}"
+  name_prefix = "${local.name_prefix}-stac-server-${data.aws_region.current.region}"
 
   policy = jsonencode({
     Version   = "2012-10-17"

--- a/modules/stac-server/opensearch_domain.tf
+++ b/modules/stac-server/opensearch_domain.tf
@@ -77,7 +77,7 @@ resource "aws_opensearch_domain" "stac_server_opensearch_domain" {
             "Action": "es:*",
             "Principal": { "AWS": "*" },
             "Effect": "Allow",
-            "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${lower(local.name_prefix)}-stac-server/*"
+            "Resource": "arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${lower(local.name_prefix)}-stac-server/*"
         }
     ]
 }
@@ -152,7 +152,7 @@ EOF
 resource "null_resource" "cleanup_opensearch_master_password_secret" {
   triggers = {
     opensearch_master_password_secret = "${local.name_prefix}-stac-server-master-creds-${random_id.suffix.hex}"
-    region                            = data.aws_region.current.name
+    region                            = data.aws_region.current.region
     account                           = data.aws_caller_identity.current.account_id
   }
 
@@ -215,7 +215,7 @@ EOF
 resource "null_resource" "cleanup_opensearch_stac_user_password_secret" {
   triggers = {
     opensearch_stac_user_password_secret = "${local.name_prefix}-stac-server-user-creds-${random_id.suffix.hex}"
-    region                               = data.aws_region.current.name
+    region                               = data.aws_region.current.region
     account                              = data.aws_caller_identity.current.account_id
   }
 
@@ -267,7 +267,7 @@ resource "aws_lambda_function" "stac_server_opensearch_user_initializer" {
       OPENSEARCH_HOST                    = var.opensearch_host != "" ? var.opensearch_host : local.opensearch_endpoint
       OPENSEARCH_MASTER_CREDS_SECRET_ARN = aws_secretsmanager_secret.opensearch_master_password_secret.arn
       OPENSEARCH_USER_CREDS_SECRET_ARN   = aws_secretsmanager_secret.opensearch_stac_user_password_secret.arn
-      REGION                             = data.aws_region.current.name
+      REGION                             = data.aws_region.current.region
     }
   }
 

--- a/modules/stac-server/opensearch_serverless.tf
+++ b/modules/stac-server/opensearch_serverless.tf
@@ -113,7 +113,7 @@ resource "aws_lambda_function" "stac_server_waiting_for_opensearch_serverless_ac
   environment {
     variables = {
       COLLECTION_NAME = lower(var.opensearch_stac_server_domain_name_override == null ? "${local.name_prefix}-stac-server" : var.opensearch_stac_server_domain_name_override)
-      REGION          = data.aws_region.current.name
+      REGION          = data.aws_region.current.region
     }
   }
 

--- a/modules/titiler/docker-images/docker-images.tf
+++ b/modules/titiler/docker-images/docker-images.tf
@@ -79,7 +79,7 @@ resource "aws_codebuild_project" "titiler_docker_image" {
 
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
-      value = data.aws_region.current.name
+      value = data.aws_region.current.region
     }
 
     environment_variable {
@@ -134,8 +134,8 @@ resource "null_resource" "trigger_codebuild" {
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-ec"]
     command     = <<EOF
-export AWS_DEFAULT_REGION=${data.aws_region.current.name}
-export AWS_REGION=${data.aws_region.current.name}
+export AWS_DEFAULT_REGION=${data.aws_region.current.region}
+export AWS_REGION=${data.aws_region.current.region}
 
 echo "Triggering CodeBuild Project."
 START_RESULT=$(aws codebuild start-build --project-name ${aws_codebuild_project.titiler_docker_image.id})
@@ -174,7 +174,7 @@ EOF
 resource "null_resource" "cleanup_bucket" {
   triggers = {
     bucket_name = aws_s3_bucket.docker_image_build_source.id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     account     = data.aws_caller_identity.current.account_id
   }
 

--- a/modules/titiler/docker-images/iam.tf
+++ b/modules/titiler/docker-images/iam.tf
@@ -48,8 +48,8 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/titiler_image_build",
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/titiler_image_build:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/titiler_image_build",
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/filmdrop/titiler_image_build:*"
       ],
       "Action": [
         "logs:CreateLogGroup",
@@ -60,8 +60,8 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/titiler-docker-image",
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/titiler-docker-image:*"
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/titiler-docker-image",
+        "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/titiler-docker-image:*"
       ],
       "Action": [
         "logs:CreateLogGroup",
@@ -72,7 +72,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::codepipeline-${data.aws_region.current.name}-*"
+        "arn:aws:s3:::codepipeline-${data.aws_region.current.region}-*"
       ],
       "Action": [
         "s3:PutObject",
@@ -91,7 +91,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
         "codebuild:BatchPutTestCases"
       ],
       "Resource": [
-        "arn:aws:codebuild:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:report-group/titiler-docker-image-*"
+        "arn:aws:codebuild:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:report-group/titiler-docker-image-*"
       ]
     },
     {
@@ -110,7 +110,7 @@ resource "aws_iam_role_policy" "docker_image_codebuild_iam_policy" {
     {
       "Effect": "Allow",
       "Action": "ec2:CreateNetworkInterfacePermission",
-      "Resource": "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+      "Resource": "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
     },
     {
       "Effect": "Allow",

--- a/modules/titiler/iam.tf
+++ b/modules/titiler/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "titiler_lambda_role" {
-  name_prefix = "titiler-${var.environment}-${data.aws_region.current.name}-lambdaRole"
+  name_prefix = "titiler-${var.environment}-${data.aws_region.current.region}-lambdaRole"
 
   assume_role_policy = <<EOF
 {
@@ -19,7 +19,7 @@ EOF
 }
 
 resource "aws_iam_policy" "titiler_lambda_policy" {
-  name_prefix = "titiler-${var.environment}-${data.aws_region.current.name}-lambdaPolicy"
+  name_prefix = "titiler-${var.environment}-${data.aws_region.current.region}-lambdaPolicy"
 
   policy = <<EOF
 {
@@ -31,7 +31,7 @@ resource "aws_iam_policy" "titiler_lambda_policy" {
                 "logs:CreateLogGroup"
             ],
             "Resource": [
-                "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/titiler*:*"
+                "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/titiler*:*"
             ],
             "Effect": "Allow"
         },
@@ -48,7 +48,7 @@ resource "aws_iam_policy" "titiler_lambda_policy" {
                 "logs:PutLogEvents"
             ],
             "Resource": [
-                "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/titiler*:*:*"
+                "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/titiler*:*:*"
             ],
             "Effect": "Allow"
         }
@@ -69,7 +69,7 @@ resource "aws_iam_role_policy_attachment" "titiler_lambda_base_policy" {
 }
 
 resource "aws_iam_role" "titiler_gw_role" {
-  name_prefix = "titiler-${var.environment}-${data.aws_region.current.name}-apigwRole"
+  name_prefix = "titiler-${var.environment}-${data.aws_region.current.region}-apigwRole"
 
   assume_role_policy = <<EOF
 {
@@ -88,7 +88,7 @@ EOF
 }
 
 resource "aws_iam_policy" "titiler_gw_policy" {
-  name_prefix = "titiler-${var.environment}-${data.aws_region.current.name}-apigwPolicy"
+  name_prefix = "titiler-${var.environment}-${data.aws_region.current.region}-apigwPolicy"
 
   policy = <<EOF
 {

--- a/profiles/analytics/main.tf
+++ b/profiles/analytics/main.tf
@@ -79,7 +79,7 @@ resource "null_resource" "cleanup_analytics_credentials" {
   triggers = {
     filmdrop_analytics_dask_secret_token = "fd-analytics-${var.project_name}-${var.environment}-admin-credentials"
     filmdrop_analytics_credentials       = "fd-analytics-${var.project_name}-${var.environment}-dask-token"
-    region                               = data.aws_region.current.name
+    region                               = data.aws_region.current.region
     account                              = data.aws_caller_identity.current.account_id
   }
 
@@ -122,7 +122,7 @@ resource "null_resource" "cleanup_analytics_stack" {
   triggers = {
     filmdrop_analytics_cluster_name = "fd-analytics-${var.project_name}-${var.environment}"
     domain_param_name               = module.cloudfront_load_balancer_endpoint.cloudfront_domain_origin_param
-    region                          = data.aws_region.current.name
+    region                          = data.aws_region.current.region
     account                         = data.aws_caller_identity.current.account_id
   }
 


### PR DESCRIPTION
## Related issue(s)

-

## Proposed Changes

- With aws provider v6 data.aws_region.current.name is deprecated in favor of data.aws_region.current.region (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#data-source-aws_region)

## Testing

This change was validated by the following observations:

- With an existing deployment, ensured this change results in no terraform changes

## Checklist

**General**

- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
