### PR TITLE
chore: managed_policy_arns deprecation

### DIFF
--- a/modules/mosaic-titiler/iam.tf
+++ b/modules/mosaic-titiler/iam.tf
@@ -40,11 +40,6 @@ resource "aws_iam_role" "titiler-mosaic-lambda-role" {
 }
 EOF
 
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-    "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-  ]
-
   inline_policy {
     name = "titiler-mosaic-lambda-inline-policy"
 
@@ -53,4 +48,14 @@ EOF
       Statement = local.titiler_policy_stmts
     })
   }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.titiler-mosaic-lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  role       = aws_iam_role.titiler-mosaic-lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }


### PR DESCRIPTION
## Related issue(s)

-

## Proposed Changes

- managed_policy_arns is deprecated, this fixes our usage

## Testing

This change was validated by the following observations:

- `terraform apply` on an existing deployment to ensure no changes

## Checklist

**General**

- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
