### PR TITLE
chore: inline_policy deprecatation

### DIFF
--- a/modules/mosaic-titiler/iam.tf
+++ b/modules/mosaic-titiler/iam.tf
@@ -39,15 +39,16 @@ resource "aws_iam_role" "titiler-mosaic-lambda-role" {
   ]
 }
 EOF
+}
 
-  inline_policy {
-    name = "titiler-mosaic-lambda-inline-policy"
+resource "aws_iam_role_policy" "titiler-mosaic-lambda-inline-policy" {
+  name = "titiler-mosaic-lambda-inline-policy"
+  role = aws_iam_role.titiler-mosaic-lambda-role.id
 
-    policy = jsonencode({
-      Version   = "2012-10-17"
-      Statement = local.titiler_policy_stmts
-    })
-  }
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = local.titiler_policy_stmts
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {


### PR DESCRIPTION
## Related issue(s)

-

## Proposed Changes

- inline_policy is deprecated, this fixes our usage

## Testing

This change was validated by the following observations:

- terraform apply on an existing deployment to ensure no material change to resources

## Checklist

**General**

- [x] I have deployed and validated this change
- [x] Changelog
  - [ ] I have added my changes to CHANGELOG.md
  - [x] No changelog entry is necessary

**If releasing a new version**

- [ ] In both CHANGELOG.md and MIGRATION.md, I have moved unreleased items to a newly created release section

**If migration step(s) might be required**

- [ ] I have added any migration steps to MIGRATION.md
