### PR TITLE
fix: skip log bucket replication when archive bucket not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Skip CloudFront log bucket replication configuration when no archive bucket is provided (`deploy_log_archive = false`). Previously, an empty `filmdrop_archive_bucket_name` would produce an invalid `arn:aws:s3:::` ARN and fail during plan.
+
 ### Removed
 
 

--- a/modules/cloudfront/custom_origin/logging.tf
+++ b/modules/cloudfront/custom_origin/logging.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "log_bucket_replication" {
-  count      = var.create_log_bucket ? 1 : 0
+  count      = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
   depends_on = [aws_s3_bucket_versioning.log_bucket_versioning]
 
   role   = aws_iam_role.cloudfront_bucket_replicator_role.arn

--- a/modules/cloudfront/s3_origin/logging.tf
+++ b/modules/cloudfront/s3_origin/logging.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "log_bucket_replication" {
-  count      = var.create_log_bucket ? 1 : 0
+  count      = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
   depends_on = [aws_s3_bucket_versioning.log_bucket_versioning]
 
   role   = aws_iam_role.cloudfront_bucket_replicator_role.arn


### PR DESCRIPTION
## Summary
 
 Guards the `aws_s3_bucket_replication_configuration` resource in both
 CloudFront logging modules so it is only created when an archive bucket
 is actually provided.
 
 ## Changes
 
 - `modules/cloudfront/s3_origin/logging.tf`: add `&& var.filmdrop_archive_bucket_name != ""`  to replication resource `count`
 - `modules/cloudfront/custom_origin/logging.tf`: same fix
 
 ## Before
 
 ```hcl
 count = var.create_log_bucket ? 1 : 0
```

After

```
 count = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
```

Testing

terragrunt plan now succeeds with deploy_log_archive = false. The log bucket is still created; replication is skipped when no 
archive destination is configured.

Fixes #256 