### PR TITLE
fix: skip VPC flow log creation when no archive bucket is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed unconditional creation of `aws_flow_log` resource in `vpc_infra` module. When `deploy_log_archive` is `false` and no archive bucket is configured, the flow log resource was still being created with an empty bucket name, producing an invalid ARN and failing deployment. The resource is now guarded with `count = var.archive_log_bucket_name != "" ? 1 : 0`.
+
 ### Removed
 
 

--- a/modules/base_infra/vpc_infra/vpc_subnets.tf
+++ b/modules/base_infra/vpc_infra/vpc_subnets.tf
@@ -47,6 +47,8 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options_association" {
 
 # Enable VPC flow logs to the FilmDrop Archive bucket
 resource "aws_flow_log" "filmdrop_vpc_flow_logs_to_s3" {
+  count = var.archive_log_bucket_name != "" ? 1 : 0
+
   log_destination          = "arn:aws:s3:::${var.archive_log_bucket_name}/vpc-flow-logs/"
   log_destination_type     = "s3"
   log_format               = var.log_format


### PR DESCRIPTION
### Summary

Adds a `count` guard to `aws_flow_log.filmdrop_vpc_flow_logs_to_s3` so the resource is only created when an archive bucket name is actually provided.

### Problem

Deploying with `deploy_log_archive = false` causes an immediate apply failure because the flow log resource always tries to construct a log destination ARN from the archive bucket name variable, which is an empty string in that configuration. AWS rejects the resulting invalid ARN.

### Change

```hcl
# modules/base_infra/vpc_infra/vpc_subnets.tf
resource "aws_flow_log" "filmdrop_vpc_flow_logs_to_s3" {
  count = var.archive_log_bucket_name != "" ? 1 : 0
  ...
}
```

### Testing

- Verified that `terraform plan` with `archive_log_bucket_name = ""` no longer attempts to create the flow log resource.
- Verified that `terraform plan` with a valid bucket name still creates the resource as expected.

### Related

Closes #258 