### PR TITLE
fix(cloudfront): skip log replication when archive bucket is empty

### DIFF
--- a/modules/cloudfront/custom_origin/logging.tf
+++ b/modules/cloudfront/custom_origin/logging.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "log_bucket_replication" {
-  count      = var.create_log_bucket ? 1 : 0
+  count      = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
   depends_on = [aws_s3_bucket_versioning.log_bucket_versioning]
 
   role   = aws_iam_role.cloudfront_bucket_replicator_role.arn

--- a/modules/cloudfront/s3_origin/logging.tf
+++ b/modules/cloudfront/s3_origin/logging.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "log_bucket_replication" {
-  count      = var.create_log_bucket ? 1 : 0
+  count      = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
   depends_on = [aws_s3_bucket_versioning.log_bucket_versioning]
 
   role   = aws_iam_role.cloudfront_bucket_replicator_role.arn


### PR DESCRIPTION
## Summary
Restore the `var.filmdrop_archive_bucket_name != ""` guard on the `count` of `aws_s3_bucket_replication_configuration.log_bucket_replication` in both `modules/cloudfront/s3_origin` and `modules/cloudfront/custom_origin`.

## What broke
With the guard removed, the replication resource gets `count = 1` whenever a CloudFront log bucket is created, even if the consumer hasn't specified an archive bucket. The replication destination then resolves to:

```hcl
bucket = "arn:aws:s3:::${var.filmdrop_archive_bucket_name}"
       = "arn:aws:s3:::"
```

…and `terraform plan` fails:

```
Error: "rule.0.destination.0.bucket" (arn:aws:s3:::) is an invalid ARN: missing resource value
  with module.filmdrop.module.filmdrop-ui[0].module.cloudfront_s3_website[0].module.cloudfront_distribution.aws_s3_bucket_replication_configuration.log_bucket_replication[0],
  on .terraform/modules/filmdrop/modules/cloudfront/s3_origin/logging.tf line 25
```

This blocks any consumer that has CloudFront logging enabled but no archive bucket configured (which is the default — `s3_logs_archive_bucket` defaults to `""` in `profiles/core`).

## Fix
Two-line change, same in both modules:

```diff
 resource "aws_s3_bucket_replication_configuration" "log_bucket_replication" {
-  count      = var.create_log_bucket ? 1 : 0
+  count      = var.create_log_bucket && var.filmdrop_archive_bucket_name != "" ? 1 : 0
```

When an archive bucket is actually specified, replication is configured exactly as before. When it isn't, the resource is skipped entirely.

## Verification
- `terraform plan` against a downstream stack with `s3_logs_archive_bucket = ""` and `ui_deploy_cloudfront = true` succeeds (previously failed with the invalid-ARN error above).
- Plan against a stack that does set `s3_logs_archive_bucket` is unchanged.