### PR TITLE
feat: surface filmdrop_ui_inputs.source_url for fork tarballs

### DIFF
--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -456,6 +456,7 @@ variable "filmdrop_ui_inputs" {
       response_page_path    = string
     }))
     version                 = string
+    source_url              = optional(string, "")
     filmdrop_ui_config_file = string
     filmdrop_ui_logo_file   = string
     filmdrop_ui_logo        = string

--- a/profiles/filmdrop-ui/inputs.tf
+++ b/profiles/filmdrop-ui/inputs.tf
@@ -50,6 +50,7 @@ variable "filmdrop_ui_inputs" {
       response_page_path    = string
     }))
     version                 = string
+    source_url              = optional(string, "")
     filmdrop_ui_config_file = string
     filmdrop_ui_logo_file   = string
     filmdrop_ui_logo        = string

--- a/profiles/filmdrop-ui/main.tf
+++ b/profiles/filmdrop-ui/main.tf
@@ -1,11 +1,15 @@
 module "filmdrop-ui" {
-  source = "git::https://github.com/Element84/terraform-aws-filmdrop-ui.git?ref=v1.0.1"
+  # Pinned to a fork branch carrying the optional filmdrop_ui_source_url input
+  # (PR Element84/terraform-aws-filmdrop-ui#10). Switch back to the official
+  # source and a tagged release once that PR is merged.
+  source = "git::https://github.com/matthewhanson/terraform-aws-filmdrop-ui.git?ref=75cbd140f2977121b9b1bce1cd42f039b638e9b1"
 
   vpc_id                 = var.vpc_id
   vpc_private_subnet_ids = var.private_subnet_ids
   vpc_security_group_ids = [var.security_group_id]
 
   filmdrop_ui_release_tag = var.filmdrop_ui_inputs.version
+  filmdrop_ui_source_url  = var.filmdrop_ui_inputs.source_url
 
   filmdrop_ui_config      = filebase64(var.filmdrop_ui_inputs.filmdrop_ui_config_file)
   filmdrop_ui_logo_file   = var.filmdrop_ui_inputs.filmdrop_ui_logo_file


### PR DESCRIPTION
## Summary

Fixes #264. Companion to Element84/terraform-aws-filmdrop-ui#10.

Surfaces the optional `filmdrop_ui_source_url` input from `terraform-aws-filmdrop-ui` (PR #10) on the `filmdrop_ui_inputs` object in the `filmdrop-ui` and `core` profiles, so downstream callers can deploy a fork's UI tarball without forking this module or `terraform-aws-filmdrop-ui`.

When `source_url` is `""` (the default), behavior is identical to today: the underlying module fetches the `Element84/filmdrop-ui` release tarball matching `filmdrop_ui_inputs.version`.

## Caveat

This PR pins `profiles/filmdrop-ui/main.tf` to a fork branch SHA of `matthewhanson/terraform-aws-filmdrop-ui` while Element84/terraform-aws-filmdrop-ui#10 is in review. **Before merging here**, that pin should be replaced with the official `Element84/terraform-aws-filmdrop-ui` source at the new tagged release that includes #10. Happy to push that bump as a follow-up commit on this branch once #10 is tagged.

## Changes

- `profiles/filmdrop-ui/inputs.tf` — `source_url` added as `optional(string, "")` to the `filmdrop_ui_inputs` object
- `profiles/core/inputs.tf` — same field on the mirror object
- `profiles/filmdrop-ui/main.tf` — passes `filmdrop_ui_source_url = var.filmdrop_ui_inputs.source_url` to the underlying module; module source SHA bumped to fork (temporary, see caveat above)

## Test plan

- [x] `terraform fmt -check` clean
- [ ] Manual: `core` profile with `filmdrop_ui_inputs.source_url = ""` deploys exactly as before
- [ ] Manual: `core` profile with `filmdrop_ui_inputs.source_url` set to a fork tarball URL deploys the fork build