### PR TITLE
feat: expose lambda_memory on filmdrop_titiler_inputs

### DIFF
--- a/profiles/core/inputs.tf
+++ b/profiles/core/inputs.tf
@@ -326,6 +326,7 @@ variable "filmdrop_titiler_inputs" {
     titiler_host_header                       = string
     mosaic_tile_timeout                       = number
     web_acl_id                                = string
+    lambda_memory                             = optional(number)
     api_provisioned_concurrency               = optional(number)
     is_private_endpoint                       = optional(bool)
     api_method_authorization_type             = optional(string)

--- a/profiles/filmdrop-titiler/inputs.tf
+++ b/profiles/filmdrop-titiler/inputs.tf
@@ -33,6 +33,7 @@ variable "filmdrop_titiler_inputs" {
     titiler_host_header                       = string
     mosaic_tile_timeout                       = number
     web_acl_id                                = string
+    lambda_memory                             = optional(number)
     is_private_endpoint                       = optional(bool)
     api_method_authorization_type             = optional(string)
     api_provisioned_concurrency               = optional(number)

--- a/profiles/filmdrop-titiler/main.tf
+++ b/profiles/filmdrop-titiler/main.tf
@@ -13,6 +13,7 @@ module "filmdrop_titiler" {
   waf_allowed_url                           = var.filmdrop_titiler_inputs.is_private_endpoint ? "" : var.filmdrop_titiler_inputs.titiler_waf_allowed_url == "" ? var.stac_url : var.filmdrop_titiler_inputs.titiler_waf_allowed_url
   request_host_header_override              = var.filmdrop_titiler_inputs.is_private_endpoint ? "" : var.filmdrop_titiler_inputs.titiler_host_header
   mosaic_tile_timeout                       = var.filmdrop_titiler_inputs.mosaic_tile_timeout
+  titiler_memory                            = coalesce(var.filmdrop_titiler_inputs.lambda_memory, 512)
   vpc_id                                    = var.vpc_id
   vpc_subnet_ids                            = var.private_subnet_ids
   vpc_security_group_ids                    = [var.security_group_id]


### PR DESCRIPTION
## Summary

Fixes #266.

Adds an optional `lambda_memory` field to the `filmdrop_titiler_inputs` object exposed by the `filmdrop-titiler` and `core` profiles, threading through to the underlying `modules/titiler` module's `titiler_memory` variable.

The default 512 MB is undersized for tile rendering of multi-band uint16 imagery (rendering a single 256x256 tile from an 8-band Planet Dove asset OOMs at 512 MB). With this field exposed, callers can dial in a size appropriate for their data without forking this module.

When the field is unset, behavior is identical to today (512 MB).

## Changes

- `profiles/filmdrop-titiler/inputs.tf` — `lambda_memory = optional(number)` added to the `filmdrop_titiler_inputs` object
- `profiles/core/inputs.tf` — same field on the mirror object
- `profiles/filmdrop-titiler/main.tf` — passes `titiler_memory = coalesce(var.filmdrop_titiler_inputs.lambda_memory, 512)` to the underlying module

## Test plan

- [x] `terraform fmt -check` clean
- [ ] Manual: with `lambda_memory` unset on `filmdrop_titiler_inputs`, plan shows `memory_size = 512` (unchanged)
- [ ] Manual: with `lambda_memory = 3008`, plan shows `memory_size = 3008` and Lambda is updated in-place